### PR TITLE
Fix: CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04"]
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11.5"]
     name: ${{ matrix.os }}-${{ matrix.python }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04"]
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
     name: ${{ matrix.os }}-${{ matrix.python }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Create and activate virtual environment
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+
       - name: Install system dependencies
         run: |
           sudo apt update
@@ -67,12 +72,14 @@ jobs:
 
       - name: Install Python dependencies
         run: |
+          source venv/bin/activate
           python -m pip install --upgrade pip
           pip install --upgrade meson-python setuptools wheel
           pip install -r tests/requirements.txt
 
       - name: Install DFAnalyzer
         run: |
+          source venv/bin/activate
           pip install .[darshan] \
             -Csetup-args="--prefix=$HOME/.local" \
             -Csetup-args="-Denable_tests=true" \
@@ -96,6 +103,7 @@ jobs:
 
       - name: Run Python tests with coverage
         run: |
+          source venv/bin/activate
           if [[ "${{ steps.test-type.outputs.run_full }}" == "true" ]]; then
             echo "Running FULL test suite"
             pytest -m full --verbose --cov=dfanalyzer --cov-report=xml
@@ -113,6 +121,7 @@ jobs:
 
       - name: Run DFAnalyzer
         run: |
+          source venv/bin/activate
           # dfanalyzer analyzer=darshan percentile=0.99 trace_path=tests/data/extracted/darshan-raw view_types=[file_name,proc_name] metrics=[time]
           dfanalyzer analyzer=darshan percentile=0.99 trace_path=tests/data/extracted/darshan-posix-dxt
           dfanalyzer analyzer=dftracer analyzer/preset=dlio percentile=0.99 trace_path=tests/data/extracted/dftracer-dlio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,13 +112,6 @@ jobs:
             pytest -m smoke --verbose --cov=dfanalyzer --cov-report=xml
           fi
 
-      - name: Run C++ tests
-        run: |
-          meson build --prefix=$HOME/.local --reconfigure -Denable_tests=true -Denable_tools=true
-          meson compile -C build --verbose
-          meson test -C build --verbose
-          meson test -C build --verbose --setup=mpi
-
       - name: Run DFAnalyzer
         run: |
           source venv/bin/activate
@@ -126,6 +119,14 @@ jobs:
           dfanalyzer analyzer=darshan percentile=0.99 trace_path=tests/data/extracted/darshan-posix-dxt
           dfanalyzer analyzer=dftracer analyzer/preset=dlio percentile=0.99 trace_path=tests/data/extracted/dftracer-dlio
           dfanalyzer analyzer=recorder percentile=0.99 trace_path=tests/data/extracted/recorder-posix-parquet
+
+      - name: Run C++ tests
+        run: |
+          rm -rf build
+          meson build --prefix=$HOME/.local -Denable_tests=true -Denable_tools=true
+          meson compile -C build --verbose
+          meson test -C build --verbose
+          meson test -C build --verbose --setup=mpi
 
       - name: Upload test coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
 
       - name: Run C++ tests
         run: |
+          source venv/bin/activate
           rm -rf build
           meson build --prefix=$HOME/.local -Denable_tests=true -Denable_tools=true
           meson compile -C build --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/dfanalyzer/__init__.py
+++ b/dfanalyzer/__init__.py
@@ -48,6 +48,7 @@ class DFAnalyzerInstance:
         percentile: Optional[float] = None,
         view_types: Optional[List[ViewType]] = None,
     ):
+        """Analyze the trace using the configured analyzer."""
         return self.analyzer.analyze_trace(
             exclude_characteristics=self.hydra_config.exclude_characteristics,
             logical_view_types=self.hydra_config.logical_view_types,
@@ -58,6 +59,12 @@ class DFAnalyzerInstance:
             unoverlapped_posix_only=self.hydra_config.unoverlapped_posix_only,
             view_types=self.hydra_config.view_types if not view_types else view_types,
         )
+
+    def shutdown(self):
+        """Shutdown the Dask client and cluster."""
+        self.client.close()
+        if hasattr(self.cluster, 'close'):
+            self.cluster.close()
 
 
 def init_with_hydra(hydra_overrides: List[str]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Analyze, visualize, and understand I/O performance issues in HPC workflows"
 authors = [{ name = "Izzet Yildirim", email = "izzetcyildirim@gmail.com" }]
 maintainers = [{ name = "Izzet Yildirim", email = "izzetcyildirim@gmail.com" }]
-requires-python = ">=3.8, <3.11"
+requires-python = ">3.8, <3.12"
 readme = { file = "README.md", content-type = "text/markdown" }
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -16,9 +16,9 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Build Tools",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -79,9 +79,9 @@ def _test_e2e(
     """Common test logic extracted to avoid duplication."""
     checkpoint_dir = f"{tmp_path}/checkpoints"
 
-    view_types = ['proc_name', 'time_range']
-    if trace_path.endswith('darshan-posix'):
-        view_types = ['file_name', 'proc_name']
+    view_types = ["proc_name", "time_range"]
+    if trace_path.endswith("darshan-posix"):
+        view_types = ["file_name", "proc_name"]
 
     dfa = init_with_hydra(
         hydra_overrides=[
@@ -97,8 +97,6 @@ def _test_e2e(
         ]
     )
 
-    # assert dfa.hydra_config.run.dir == tmp_path.as_posix()
-    # assert dfa.hydra_config.runtime.output_dir == tmp_path.as_posix()
     assert dfa.hydra_config.analyzer.checkpoint == checkpoint
     assert dfa.hydra_config.analyzer.checkpoint_dir == checkpoint_dir
     assert dfa.hydra_config.analyzer.preset.name == preset
@@ -116,3 +114,6 @@ def _test_e2e(
     )
     if checkpoint:
         assert any(glob(f"{result.checkpoint_dir}/*.json")), "No checkpoint found"
+
+    # Shutdown the Dask client and cluster
+    dfa.shutdown()


### PR DESCRIPTION
This pull request introduces several updates to the CI workflow, Python environment setup, and codebase improvements, including support for Python 3.11, enhanced virtual environment management, and new functionality for shutting down resources in the `dfanalyzer` module. Below is a categorized summary of the most important changes:

### CI Workflow and Python Environment Updates:
* Updated the CI matrix to test Python versions 3.9, 3.10, and 3.11.5, and adjusted the `requires-python` field in `pyproject.toml` to support Python versions `>3.8, <3.12`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL23-R23) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L11-R21)
* Added virtual environment creation and activation steps in the CI workflow to ensure isolated environments for dependency installation and testing.
* Ensured the virtual environment is activated before installing dependencies, running tests, and executing the `dfanalyzer` tool. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR75-R82) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR106) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL107-R131)

### Codebase Enhancements:
* Introduced a `shutdown` method in the `dfanalyzer` module to cleanly close the Dask client and cluster, improving resource management.
* Added a docstring to the `analyze_trace` method in the `dfanalyzer` module to clarify its purpose.

### Testing Improvements:
* Updated `_test_e2e` in `tests/test_main.py` to include a call to the new `shutdown` method, ensuring proper cleanup of resources after tests.
* Standardized string formatting in `_test_e2e` to use double quotes for consistency.