### PR TITLE
Enhance: Add offset handling in DFTracerAnalyzer

### DIFF
--- a/dfanalyzer/analysis_utils.py
+++ b/dfanalyzer/analysis_utils.py
@@ -33,10 +33,7 @@ def fix_dtypes(df: pd.DataFrame):
     double_cols.extend([col for col in df.columns if col.endswith('_slope')])
     double_cols.extend([col for col in df.columns if col.endswith('_pct')])
     size_cols = [col for col in df.columns if col.endswith('_size')]
-    # df[int_cols] = df[int_cols].astype('int64[pyarrow]')
-    # df[double_cols] = df[double_cols].astype('double[pyarrow]')
-    # df[size_cols] = df[size_cols].astype('int64[pyarrow]')
-    df[int_cols] = df[int_cols].astype('Int32')
+    df[int_cols] = df[int_cols].astype('Int64')
     df[double_cols] = df[double_cols].astype('Float64')
     df[size_cols] = df[size_cols].astype('Int64')
     return df

--- a/dfanalyzer/dftracer.py
+++ b/dfanalyzer/dftracer.py
@@ -192,6 +192,7 @@ def io_columns():
         "image_id": "uint64[pyarrow]",
         "io_cat": "uint8[pyarrow]",
         "size": "uint64[pyarrow]",
+        "offset": "uint64[pyarrow]",
     }
     return columns
 
@@ -212,6 +213,10 @@ def io_function(json_dict: dict):
                 if size > 0:
                     if io_cat in [IOCategory.READ.value, IOCategory.WRITE.value]:
                         d["size"] = size
+            if "offset" in json_dict["args"]:
+                offset = int(json_dict["args"]["offset"])
+                if offset >= 0:
+                    d["offset"] = offset
             d[COL_IO_CAT] = io_cat
         else:
             if "image_idx" in json_dict["args"]:
@@ -692,6 +697,7 @@ class DFTracerAnalyzer(Analyzer):
         )
 
         traces["size"] = traces["size"].replace(0, np.nan)
+        traces["offset"] = traces["offset"].replace(0, np.nan)
 
         return traces
 

--- a/dfanalyzer/dftracer.py
+++ b/dfanalyzer/dftracer.py
@@ -697,7 +697,8 @@ class DFTracerAnalyzer(Analyzer):
         )
 
         traces["size"] = traces["size"].replace(0, np.nan)
-        traces["offset"] = traces["offset"].replace(0, np.nan)
+        if "offset" in traces.columns:
+            traces["offset"] = traces["offset"].replace(0, np.nan)
 
         return traces
 


### PR DESCRIPTION
This pull request introduces changes to improve data type handling and extend functionality for processing I/O traces in the `dfanalyzer` module. The most important changes include adjustments to column data types, the addition of a new `offset` column, and updates to ensure proper handling of the `offset` field in I/O trace processing.

### Data type adjustments:
* Updated the integer column data type in `fix_dtypes` to use `Int64` instead of `Int32` for consistency with other integer columns (`dfanalyzer/analysis_utils.py`, [dfanalyzer/analysis_utils.pyL36-R36](diffhunk://#diff-3d3481806c53a47655216937a5d31709264cf1e0ef01ca649cfa802fd73d7666L36-R36)).

### Enhancements to I/O trace processing:
* Added a new `offset` column to the schema returned by `io_columns` to capture offset information (`dfanalyzer/dftracer.py`, [dfanalyzer/dftracer.pyR195](diffhunk://#diff-0ce5258cfee94c40796fd85ec80767f9876c21cbdbed90330e874cde742fe860R195)).
* Updated `io_function` to extract and include the `offset` field from `json_dict` arguments if present and valid (`dfanalyzer/dftracer.py`, [dfanalyzer/dftracer.pyR216-R219](diffhunk://#diff-0ce5258cfee94c40796fd85ec80767f9876c21cbdbed90330e874cde742fe860R216-R219)).
* Modified `postread_trace` to replace zero values in the `offset` column with `NaN` for better handling of missing data (`dfanalyzer/dftracer.py`, [dfanalyzer/dftracer.pyR700](diffhunk://#diff-0ce5258cfee94c40796fd85ec80767f9876c21cbdbed90330e874cde742fe860R700)).