### PR TITLE
[CI] Fix branch names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Build and Test
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   push:
-    branches: [main, dev]
+    branches: [main, develop]
     tags:
       - "v*.*.*" # Match version tags like v1.0.0, v0.1.2, etc.
   workflow_dispatch:

--- a/python/dftracer/analyzer/darshan.py
+++ b/python/dftracer/analyzer/darshan.py
@@ -9,6 +9,8 @@ from .analyzer import Analyzer
 from .constants import COL_TIME_END, COL_TIME_START, IOCategory
 from .types import RawStats
 
+DEFAULT_APP_NAME = 'app'
+DEFAULT_HOST_NAME = 'localhost'
 TRACE_COL_MAPPING = {
     'end_time': COL_TIME_END,
     'start_time': COL_TIME_START,
@@ -116,7 +118,7 @@ class DarshanAnalyzer(Analyzer):
             rank = record['rank']
             host_name = record['hostname']
             file_name = report.data['name_records'][file_id]
-            proc_name = f"app#localhost#{rank}#0"
+            proc_name = f"{DEFAULT_APP_NAME}#{DEFAULT_HOST_NAME}#{rank}#0"
 
             # Process read segments
             if not record['read_segments'].empty:
@@ -213,7 +215,9 @@ class DarshanAnalyzer(Analyzer):
                 right_index=True,
             )
             .reset_index()
-            .assign(proc_name=lambda x: 'app#localhost#' + x['rank'].astype(str) + '#0')
+            .assign(app_name=lambda x: DEFAULT_APP_NAME)
+            .assign(host_name=lambda x: DEFAULT_HOST_NAME)
+            .assign(proc_name=lambda x: x['app_name'] + '#' + x['host_name'] + '#' + x['rank'].astype(str) + '#0')
             # .set_index(['proc_name', 'file_name'])
             .drop(columns=['id', 'rank'])
             .query('~(file_name.str.startswith("<") and file_name.str.endswith(">"))')


### PR DESCRIPTION
This pull request updates the CI workflow configuration to ensure that build and test actions are triggered for both the `main` and `develop` branches, instead of just `main` and `dev`.

CI workflow configuration updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL5-R7): Modified the list of branches for both `pull_request` and `push` events to include `develop` instead of `dev`, ensuring CI runs on both `main` and `develop` branches.