### PR TITLE
[Docs] Fix PyPI package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Data Flow Analyzer
 
-<!-- ![Build and Test](https://github.com/LLNL/dfanalyzer/actions/workflows/ci.yml/badge.svg)
-![PyPI - Version](https://img.shields.io/pypi/v/dfanalyzer?label=PyPI)
-![PyPI - Wheel](https://img.shields.io/pypi/wheel/dfanalyzer?label=Wheel)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dfanalyzer?label=Python) -->
+![Build and Test](https://github.com/LLNL/dfanalyzer/actions/workflows/ci.yml/badge.svg)
+![PyPI - Version](https://img.shields.io/pypi/v/dftracer-analyzer?label=PyPI)
+![PyPI - Wheel](https://img.shields.io/pypi/wheel/dftracer-analyzer?label=Wheel)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dftracer-analyzer?label=Python)
 
 ## Overview
 
@@ -18,7 +18,7 @@ To install DFAnalyzer through `pip` (recommended for most users):
 # This might involve using your system's package manager or a tool like Spack.
 # Example using Spack to prepare the environment:
 # spack -e tools install
-pip install dfanalyzer
+pip install dftracer-analyzer
 ```
 
 To install DFAnalyzer from source (for developers or custom builds):

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -12,7 +12,7 @@ To install DFAnalyzer through ``pip`` (recommended for most users):
    # This might involve using your system's package manager or a tool like Spack.
    # Example using Spack to prepare the environment:
    # spack -e tools install
-   pip install dfanalyzer
+   pip install dftracer-analyzer
 
 To install DFAnalyzer from source (for developers or custom builds):
 


### PR DESCRIPTION
This pull request updates the documentation to reflect a change in the package name from `dfanalyzer` to `dftracer-analyzer`. The most important changes are updates to the installation instructions and status badges to ensure users reference the correct package.

**Documentation updates for package rename:**

* Updated all `pip install` instructions in both `README.md` and `docs/getting-started.rst` to use `dftracer-analyzer` instead of `dfanalyzer`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R21) [[2]](diffhunk://#diff-a45f0de34d7ed82da3d15d99a01a319140f3381a730690530b853efb795aaff0L15-R15)
* Updated status badges in `README.md` to point to the new `dftracer-analyzer` package on PyPI, including version, wheel, and supported Python versions.