### PR TITLE
[Fix] Pin `meson` version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,7 +41,6 @@ jobs:
             libopenmpi-dev \
             libparquet-dev \
             libreadline-dev \
-            meson \
             ninja-build \
             nlohmann-json3-dev \
             openmpi-bin \
@@ -49,7 +48,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade auditwheel build meson-python patchelf setuptools wheel
+          pip install --upgrade auditwheel build "meson>=1.5.0,<1.10.0" meson-python patchelf setuptools wheel
       - name: Build DFAnalyzer
         run: |
           python3 -m build -Csetup-args="--prefix=$HOME/.local" -Csetup-args="-Denable_tools=true" .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
             libopenmpi-dev \
             libparquet-dev \
             libreadline-dev \
-            meson \
             ninja-build \
             nlohmann-json3-dev \
             openmpi-bin \
@@ -69,7 +68,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade meson-python setuptools wheel
+          pip install --upgrade "meson>=1.5.0,<1.10.0" meson-python setuptools wheel
           pip install -r tests/requirements.txt
 
       - name: Install DFAnalyzer

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update && \
     libopenmpi-dev \
     libparquet-dev \
     libreadline-dev \
-    meson \
     ninja-build \
     nlohmann-json3-dev \
     openmpi-bin \
@@ -32,7 +31,7 @@ WORKDIR /dfanalyzer
 COPY . .
 
 RUN pip install --upgrade pip && \
-    pip install build meson-python setuptools streamlit wheel && \
+    pip install build "meson>=1.5.0,<1.10.0" meson-python setuptools streamlit wheel && \
     pip install .[darshan] -Csetup-args="-Denable_tools=true"
 
 ENTRYPOINT ["dfanalyzer"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "mesonpy"
-requires = ["meson-python>=0.15.0", "meson>=1.5.0"]
+requires = ["meson>=1.5.0,<1.10.0", "meson-python>=0.15.0"]
 
 [project]
 name = "dftracer-analyzer"


### PR DESCRIPTION
`meson`'s 1.10.0 [introduced regression](https://github.com/mesonbuild/meson/issues/15360) in CMake builds. This PR pins its version (for now) to a working one. 

This is the reason why CI failed after #42 was merged.