### PR TITLE
[Fix] Pin Pandas version & done future-proof type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "hydra-core~=1.3.0",
     "inflect==7.0",
     "numpy>=2.0.0",
-    "pandas>=2.2.0",
+    "pandas>=2.2.0,<3.0.0",
     "portion>=2.4.0",
     "pyarrow>=13",
     "rich~=14.1.0",

--- a/python/dftracer/analyzer/analyzer.py
+++ b/python/dftracer/analyzer/analyzer.py
@@ -703,10 +703,10 @@ class Analyzer(abc.ABC):
                     continue
                 metric_col = f"{metric}_{col}"
                 hlm[metric_col] = pd.NA
-                if hlm.dtypes[col].name == "object" and not is_data_col:
+                if pd.api.types.is_string_dtype(hlm.dtypes[col]) and not is_data_col:
                     hlm[metric_col] = hlm[metric_col].map(lambda x: S())
                 hlm[metric_col] = hlm[metric_col].mask(hlm.eval(condition), hlm[col])
-                if hlm.dtypes[col].name != "object":
+                if not pd.api.types.is_string_dtype(hlm.dtypes[col]):
                     hlm[metric_col] = pd.to_numeric(hlm[metric_col], errors="coerce")
         return hlm
 


### PR DESCRIPTION
This pull request introduces a version constraint on the `pandas` dependency and refines type checking for string columns in the `set_layer_metrics` function to improve compatibility and robustness.

Dependency management:

* Updated the `pyproject.toml` to restrict the `pandas` dependency to versions `>=2.2.0,<3.0.0` to prevent compatibility issues with future major releases.

Code robustness and pandas compatibility:

* In `python/dftracer/analyzer/analyzer.py`, replaced direct checks for `"object"` dtype with `pd.api.types.is_string_dtype` for more accurate and future-proof string column detection in the `set_layer_metrics` function. This improves handling of string columns and aligns with best practices for pandas type checking.