### PR TITLE
[Fix] Flattening atomic strings in groupby

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "betterset>=0.1.0",
+    "betterset>=0.2.0",
     "dask[bag,dataframe,distributed]>=2024.1.0,<2025",
     "dask_jobqueue>=0.8.0",
     "hydra-core~=1.3.0",

--- a/tests/utils/test_dask_agg.py
+++ b/tests/utils/test_dask_agg.py
@@ -74,6 +74,27 @@ def test_unique_set_flatten_grouped_three_stage_via_dask():
     assert set(res.loc["w"]) == {2, 3, 4}
 
 
+def test_unique_set_flatten_handles_strings_via_dask():
+    df = pd.DataFrame(
+        [
+            {"g": "a", "p": "x", "col": "foo"},
+            {"g": "a", "p": "x", "col": "bar"},
+            {"g": "a", "p": "y", "col": "bar"},
+            {"g": "b", "p": "y", "col": "baz"},
+        ]
+    )
+    ddf = dd.from_pandas(df, npartitions=2)
+    res = (
+        ddf.groupby(["g", "p"])
+        .agg({"col": unique_set()})
+        .groupby(["p"])
+        .agg({"col": unique_set_flatten()})
+        .compute()["col"]
+    )
+    assert set(res.loc["x"]) == {"foo", "bar"}
+    assert set(res.loc["y"]) == {"bar", "baz"}
+
+
 def test_unique_set_handles_missing_values_via_dask():
     df = pd.DataFrame(
         [


### PR DESCRIPTION
This pull request updates a dependency and adds a new test to improve coverage for string handling in Dask aggregation utilities.

Dependency update:

* Updated the `betterset` dependency version requirement from `>=0.1.0` to `>=0.2.0` in `pyproject.toml`, ensuring compatibility with the latest features and bug fixes.

Testing improvements:

* Added a new test, `test_unique_set_flatten_handles_strings_via_dask`, to verify that the `unique_set_flatten` aggregation correctly handles string values when used with Dask DataFrames.