### PR TITLE
Add configurable `size_layers` and `size_derived_metrics` for layer-specific size metric handling

### DIFF
--- a/python/dftracer/analyzer/analyzer.py
+++ b/python/dftracer/analyzer/analyzer.py
@@ -1003,7 +1003,7 @@ class Analyzer(abc.ABC):
             hlm = hlm.map_partitions(
                 self.set_layer_metrics,
                 derived_metrics=self.preset.derived_metrics[layer],
-                size_derived_metrics=(self.preset.size_derived_metrics or {}).get(layer, []),
+                size_derived_metrics=(self.preset.size_derived_metrics or {}).get(layer.lower(), []),
             )
         with log_block("build_agg_dict", layer=layer):
             view_types_diff = set(VIEW_TYPES).difference(view_types)

--- a/python/dftracer/analyzer/analyzer.py
+++ b/python/dftracer/analyzer/analyzer.py
@@ -691,19 +691,24 @@ class Analyzer(abc.ABC):
             return fallback()
 
     @staticmethod
-    def set_layer_metrics(hlm: pd.DataFrame, derived_metrics: Dict[str, str]) -> pd.DataFrame:
+    def set_layer_metrics(
+        hlm: pd.DataFrame,
+        derived_metrics: Dict[str, str],
+        size_derived_metrics: Optional[List[str]] = None,
+    ) -> pd.DataFrame:
         # Create an explicit copy to avoid SettingWithCopyWarning
         hlm = hlm.copy()
         hlm_columns = list(hlm.columns)
+        size_derived_metric_set = set(size_derived_metrics or [])
         for metric, condition in derived_metrics.items():
-            is_data_metric = metric in ["data", "read", "write"]
+            is_size_metric = metric in size_derived_metric_set
             for col in hlm_columns:
-                is_data_col = col == "size" or "size_bin" in col
-                if not is_data_metric and is_data_col:
+                is_size_col = col == "size" or "size_bin" in col
+                if not is_size_metric and is_size_col:
                     continue
                 metric_col = f"{metric}_{col}"
                 hlm[metric_col] = pd.NA
-                if pd.api.types.is_string_dtype(hlm.dtypes[col]) and not is_data_col:
+                if pd.api.types.is_string_dtype(hlm.dtypes[col]) and not is_size_col:
                     hlm[metric_col] = hlm[metric_col].map(lambda x: S())
                 hlm[metric_col] = hlm[metric_col].mask(hlm.eval(condition), hlm[col])
                 if not pd.api.types.is_string_dtype(hlm.dtypes[col]):
@@ -988,12 +993,18 @@ class Analyzer(abc.ABC):
         partition_size: str,
     ) -> dd.DataFrame:
         with log_block("drop_and_set_metrics", layer=layer):
-            if "posix" not in layer.lower():
+            size_layers = {configured_layer.lower() for configured_layer in (self.preset.size_layers or [])}
+            keep_size_for_layer = layer.lower() in size_layers
+            if not keep_size_for_layer:
                 size_cols = [col for col in hlm.columns if col.startswith("size")]
                 hlm = hlm.drop(columns=size_cols)  # type: ignore
                 if "file_name" in hlm.columns:
                     hlm = hlm.drop(columns=["file_name"])  # type: ignore
-            hlm = hlm.map_partitions(self.set_layer_metrics, derived_metrics=self.preset.derived_metrics[layer])
+            hlm = hlm.map_partitions(
+                self.set_layer_metrics,
+                derived_metrics=self.preset.derived_metrics[layer],
+                size_derived_metrics=(self.preset.size_derived_metrics or {}).get(layer, []),
+            )
         with log_block("build_agg_dict", layer=layer):
             view_types_diff = set(VIEW_TYPES).difference(view_types)
             main_view_agg = {}

--- a/python/dftracer/analyzer/config.py
+++ b/python/dftracer/analyzer/config.py
@@ -25,6 +25,7 @@ DERIVED_POSIX_METRICS = {
     'other': 'io_cat == 6',
     'sync': 'io_cat == 7',
 }
+DERIVED_POSIX_SIZE_METRICS = ['data', 'read', 'write']
 HASH_CHECKPOINT_NAMES = get_bool_env_var("DFANALYZER_HASH_CHECKPOINT_NAMES", False)
 
 
@@ -37,6 +38,8 @@ class AnalyzerPresetConfig:
     layer_deps: Optional[Dict[str, Optional[str]]] = dc.field(default_factory=dict)
     logical_views: Optional[Dict[str, Dict[str, Optional[str]]]] = dc.field(default_factory=dict)
     name: str = MISSING
+    size_derived_metrics: Optional[Dict[str, List[str]]] = dc.field(default_factory=dict)
+    size_layers: Optional[List[str]] = dc.field(default_factory=list)
     unscored_metrics: Optional[List[str]] = dc.field(default_factory=list)
 
 
@@ -66,6 +69,12 @@ class AnalyzerPresetConfigPOSIX(AnalyzerPresetConfig):
         }
     )
     name: str = "posix"
+    size_derived_metrics: Optional[Dict[str, List[str]]] = dc.field(
+        default_factory=lambda: {
+            'posix': list(DERIVED_POSIX_SIZE_METRICS),
+        }
+    )
+    size_layers: Optional[List[str]] = dc.field(default_factory=lambda: ['posix'])
 
 
 @dc.dataclass
@@ -174,6 +183,20 @@ class AnalyzerPresetConfigDLIO(AnalyzerPresetConfig):
         }
     )
     name: str = "dlio"
+    size_derived_metrics: Optional[Dict[str, List[str]]] = dc.field(
+        default_factory=lambda: {
+            'posix': list(DERIVED_POSIX_SIZE_METRICS),
+            'reader_posix': list(DERIVED_POSIX_SIZE_METRICS),
+            'checkpoint_posix': list(DERIVED_POSIX_SIZE_METRICS),
+        }
+    )
+    size_layers: Optional[List[str]] = dc.field(
+        default_factory=lambda: [
+            'posix',
+            'reader_posix',
+            'checkpoint_posix',
+        ]
+    )
     unscored_metrics: Optional[List[str]] = dc.field(default_factory=list)
 
 

--- a/python/dftracer/analyzer/config.py
+++ b/python/dftracer/analyzer/config.py
@@ -25,7 +25,7 @@ DERIVED_POSIX_METRICS = {
     'other': 'io_cat == 6',
     'sync': 'io_cat == 7',
 }
-DERIVED_POSIX_SIZE_METRICS = ['data', 'read', 'write']
+DERIVED_POSIX_SIZE_METRICS = ('data', 'read', 'write')
 HASH_CHECKPOINT_NAMES = get_bool_env_var("DFANALYZER_HASH_CHECKPOINT_NAMES", False)
 
 

--- a/python/dftracer/analyzer/dftracer.py
+++ b/python/dftracer/analyzer/dftracer.py
@@ -166,13 +166,13 @@ def io_function(json_dict: dict):
                 image_id = int(json_dict["args"]["image_idx"])
                 if image_id > 0:
                     d["image_id"] = image_id
-            # if "image_size" in json_object["args"]:
-            #     name = json_object["name"].lower()
-            #     # e.g. NPZReader.open image_size is not correct
-            #     if 'reader.open' not in name:
-            #         size = int(json_object["args"]["image_size"])
-            #         if size > 0:
-            #             d["size"] = size
+            if "image_size" in json_dict["args"]:
+                name = json_dict["name"].lower()
+                # e.g. NPZReader.open image_size is not correct
+                if "open" not in name:
+                    size = int(json_dict["args"]["image_size"])
+                    if size > 0:
+                        d["size"] = size
     return d
 
 


### PR DESCRIPTION
This pull request introduces a more flexible system for handling "size" metrics and layers in the analyzer configuration and processing logic. The main improvements are the ability to specify which layers and metrics should be treated as "size" related, and to propagate these settings throughout the analyzer pipeline. This enhances configurability for different storage backends and analysis presets.

**Configuration enhancements:**

* Added `size_derived_metrics` and `size_layers` fields to the `AnalyzerPresetConfig` dataclass, with appropriate defaults for POSIX and DLIO presets, allowing each preset to specify which layers and metrics are considered "size"-related. [[1]](diffhunk://#diff-43bda7d9bedc85c865c653a6ddd27e4a62f210e3f654de3dc830d9690e28b5a9R41-R42) [[2]](diffhunk://#diff-43bda7d9bedc85c865c653a6ddd27e4a62f210e3f654de3dc830d9690e28b5a9R72-R77) [[3]](diffhunk://#diff-43bda7d9bedc85c865c653a6ddd27e4a62f210e3f654de3dc830d9690e28b5a9R186-R199)
* Introduced `DERIVED_POSIX_SIZE_METRICS` constant to centralize the list of metrics considered as size-related for POSIX.

**Analyzer logic updates:**

* Modified the `set_layer_metrics` method in `analyzer.py` to accept a `size_derived_metrics` argument, and use it to determine which metrics should be treated as size-related, improving flexibility and reducing hardcoding.
* Updated the `_compute_main_view` method to use the new configuration fields, ensuring that size columns and metrics are handled correctly based on the current layer and preset.

**Bug fix / data extraction improvement:**

* Fixed the logic for extracting `image_size` in `io_function` to only assign the `size` field when the operation name does not include "open", ensuring more accurate data attribution.