### PR TITLE
Add view-scoped additional metrics and console reporting

### DIFF
--- a/python/dftracer/analyzer/analyzer.py
+++ b/python/dftracer/analyzer/analyzer.py
@@ -953,6 +953,10 @@ class Analyzer(abc.ABC):
             _hlms=hlms,
             _main_views=main_views,
             _metric_boundaries=metric_boundaries,
+            additional_metrics={
+                view_type: list(metrics.keys())
+                for view_type, metrics in (self.preset.additional_metrics or {}).items()
+            },  # type: ignore
             checkpoint_dir=self.checkpoint_dir,
             flat_views=flat_views,
             layers=self.layers,
@@ -1114,16 +1118,22 @@ class Analyzer(abc.ABC):
                 time_boundary_layer=self.get_time_boundary_layer(),
             )
         with log_block("set_additional_metrics", view_key=view_key):
-            flat_view = self._set_additional_metrics(flat_view, is_view_process_based=is_view_process_based)
+            flat_view = self._set_additional_metrics(
+                flat_view,
+                view_key=view_key,
+            )
         return flat_view.sort_index(axis=1)
 
     @staticmethod
     def _save_flat_view(view: pd.DataFrame, view_path: str):
         view.to_parquet(f"{view_path}.parquet")
 
-    def _set_additional_metrics(self, view: pd.DataFrame, is_view_process_based: bool, epsilon=1e-9) -> pd.DataFrame:
+    def _set_additional_metrics(self, view: pd.DataFrame, view_key: ViewKey, epsilon=1e-9) -> pd.DataFrame:
+        view_type = view_key[-1]
+        is_view_process_based = self.is_view_process_based(view_key)
         time_metric = "time_sum" if is_view_process_based else "time_max"
-        for metric, eval_condition in self.preset.additional_metrics.items():
+        view_additional_metrics = (self.preset.additional_metrics or {}).get(view_type, {})
+        for metric, eval_condition in view_additional_metrics.items():
             eval_condition = eval_condition.format(
                 epsilon=epsilon,
                 time_interval=self.time_granularity,

--- a/python/dftracer/analyzer/config.py
+++ b/python/dftracer/analyzer/config.py
@@ -31,7 +31,7 @@ HASH_CHECKPOINT_NAMES = get_bool_env_var("DFANALYZER_HASH_CHECKPOINT_NAMES", Fal
 
 @dc.dataclass
 class AnalyzerPresetConfig:
-    additional_metrics: Optional[Dict[str, Optional[str]]] = dc.field(default_factory=dict)
+    additional_metrics: Optional[Dict[str, Dict[str, str]]] = dc.field(default_factory=dict)
     async_layers: Optional[List[str]] = dc.field(default_factory=list)
     derived_metrics: Optional[Dict[str, Dict[str, str]]] = dc.field(default_factory=dict)
     layer_defs: Dict[str, Optional[str]] = MISSING

--- a/python/dftracer/analyzer/output.py
+++ b/python/dftracer/analyzer/output.py
@@ -3,12 +3,13 @@ import colorsys
 import dask
 import dataclasses as dc
 import inflect
+import numpy as np
 import pandas as pd
 from rich.console import Console
 from rich.table import Table
 from typing import Dict, List, Optional
 
-from .constants import COL_PROC_NAME, HUMANIZED_LAYERS, Layer, MiB
+from .constants import COL_PROC_NAME, HUMANIZED_LAYERS, GiB, Layer, MiB
 from .types import (
     AnalyzerResultType,
     RawStats,
@@ -155,6 +156,9 @@ class ConsoleOutput(Output):
             summary_table = self._create_summary_table(summary=summary, view_key=view_key)
             layer_breakdown_table = self._create_layer_breakdown_table(summary=summary, view_key=view_key)
             print_objects.append(summary_table)
+            additional_metrics_table = self._create_additional_metrics_table(result=result, view_key=view_key)
+            if additional_metrics_table is not None:
+                print_objects.append(additional_metrics_table)
             print_objects.append(layer_breakdown_table)
         console = Console(record=True)
         console.print(*print_objects)
@@ -231,6 +235,63 @@ class ConsoleOutput(Output):
                 summary_table.add_row(f"{layer_name} Avg Transfer Size", 'MB', f"{avg_xfer_size / MiB:.3f}")
 
         return summary_table
+
+    def _create_additional_metrics_table(self, result: AnalyzerResultType, view_key: ViewKey) -> Optional[Table]:
+        if not result.additional_metrics:
+            return None
+
+        flat_view = result.flat_views[view_key]
+        view_type = view_key[-1]
+        view_additional_metrics = result.additional_metrics.get(view_type, [])
+        if not view_additional_metrics:
+            return None
+        view_name = humanized_view_name(view_key, ' ')
+        additional_table = Table(title=f"{view_name} Additional Metrics", title_style='bold magenta', expand=True)
+        additional_table.add_column(header='Metric', style='bold')
+        additional_table.add_column(header='Unit', style='italic')
+        additional_table.add_column(header='Non-null', justify='right')
+        additional_table.add_column(header='Min', justify='right')
+        additional_table.add_column(header='Mean', justify='right')
+        additional_table.add_column(header='Max', justify='right')
+
+        found_metric = False
+        for metric in view_additional_metrics:
+            if metric not in flat_view.columns:
+                continue
+            metric_series = pd.to_numeric(flat_view[metric], errors='coerce').replace([np.inf, -np.inf], pd.NA)
+            scale, unit = self._additional_metric_scale_and_unit(metric)
+            metric_series = metric_series / scale
+            non_null = int(metric_series.notna().sum())
+            if non_null == 0:
+                additional_table.add_row(metric, unit, "0", "-", "-", "-")
+                found_metric = True
+                continue
+            additional_table.add_row(
+                metric,
+                unit,
+                f"{non_null:,}",
+                f"{float(metric_series.min()):.3f}",
+                f"{float(metric_series.mean()):.3f}",
+                f"{float(metric_series.max()):.3f}",
+            )
+            found_metric = True
+
+        if not found_metric:
+            return None
+        return additional_table
+
+    @staticmethod
+    def _additional_metric_scale_and_unit(metric: str):
+        metric_lower = metric.lower()
+        if metric_lower.endswith('_gbps'):
+            return GiB, 'GB/s'
+        if metric_lower.endswith('_mbps'):
+            return MiB, 'MB/s'
+        if metric_lower.endswith('_gb'):
+            return GiB, 'GB'
+        if metric_lower.endswith('_mb'):
+            return MiB, 'MB'
+        return 1.0, '-'
 
     def _format_val(self, value: float, fmt_int=False) -> str:
         if value is None or value == 0:

--- a/python/dftracer/analyzer/types.py
+++ b/python/dftracer/analyzer/types.py
@@ -192,6 +192,7 @@ class OutputType:
 
 @dc.dataclass
 class AnalyzerResultType:
+    additional_metrics: Dict[ViewType, List[str]]
     checkpoint_dir: str
     flat_views: Dict[ViewKey, pd.DataFrame]
     layers: List[Layer]


### PR DESCRIPTION
This pull request introduces support for handling and displaying additional metrics in the analyzer output, with changes spanning configuration, processing, and presentation. The main improvements include refactoring the configuration for additional metrics to support per-view-type metrics, updating the analysis pipeline to process these metrics correctly, and adding a new summary table for additional metrics in the output.

```
                                                             Time Period Summary                                                              
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Metric                                                                                  ┃ Unit                ┃                      Value ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ Job Time                                                                                │ seconds             │                   1060.279 │
│ Total Count                                                                             │ count               │                    142,462 │
│ Total Files                                                                             │ count               │                         29 │
│ Total Nodes                                                                             │ count               │                          1 │
│ Total Processes                                                                         │ count               │                         12 │
│ Training Count                                                                          │ count               │                          2 │
│ Checkpoint Count                                                                        │ count               │                          4 │
│ Data Loader Count                                                                       │ count               │                     70,270 │
│ Data Loader Fork Count                                                                  │ count               │                         20 │
│ Reader Count                                                                            │ count               │                     10,763 │
│ POSIX - All Count                                                                       │ count               │                      7,647 │
│ POSIX - All Size                                                                        │ MB                  │                 118004.580 │
│ POSIX - All Bandwidth                                                                   │ MB/s                │                   4737.244 │
│ POSIX - All Avg Transfer Size                                                           │ MB                  │                     15.431 │
│ POSIX - Reader Count                                                                    │ count               │                        183 │
│ POSIX - Reader Size                                                                     │ MB                  │                     24.349 │
│ POSIX - Reader Bandwidth                                                                │ MB/s                │                    483.476 │
│ POSIX - Reader Avg Transfer Size                                                        │ MB                  │                      0.133 │
│ POSIX - Checkpoint Count                                                                │ count               │                      7,354 │
│ POSIX - Checkpoint Size                                                                 │ MB                  │                 117976.232 │
│ POSIX - Checkpoint Bandwidth                                                            │ MB/s                │                   4769.542 │
│ POSIX - Checkpoint Avg Transfer Size                                                    │ MB                  │                     16.042 │
└─────────────────────────────────────────────────────────────────────────────────────────┴─────────────────────┴────────────────────────────┘
                                                        Time Period Additional Metrics                                                        
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
┃ Metric                               ┃ Unit          ┃                Non-null ┃              Min ┃               Mean ┃               Max ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
│ image_bw_mbps                        │ MB/s          │                     970 │            0.286 │             31.461 │            43.843 │
└──────────────────────────────────────┴───────────────┴─────────────────────────┴──────────────────┴────────────────────┴───────────────────┘
```

**Configuration and Data Model Updates**
* Refactored the `AnalyzerPresetConfig` dataclass to allow specifying additional metrics as a dictionary mapping view types to their respective metrics, enabling more granular control over which metrics are tracked for each view type.
* Updated the `AnalyzerResultType` dataclass to include an `additional_metrics` field, which stores the list of additional metrics for each view type.

**Analysis Pipeline Changes**
* Modified the `_analyze_hlm` and `_process_flat_view` methods in `analyzer.py` to correctly pass and process additional metrics per view type, ensuring metrics are set and evaluated based on the view type rather than globally. [[1]](diffhunk://#diff-444fe7b2c8a8f206c6c5f1ffcc69a1cbb5e4afa07a156946134fa0f9f9471203R956-R959) [[2]](diffhunk://#diff-444fe7b2c8a8f206c6c5f1ffcc69a1cbb5e4afa07a156946134fa0f9f9471203L1117-R1136)

**Output and Presentation Enhancements**
* Added the `_create_additional_metrics_table` method to `output.py`, which generates a summary table for additional metrics including unit conversion, non-null counts, and basic statistics (min, mean, max) for each metric. The table is conditionally displayed if additional metrics are present for the current view. [[1]](diffhunk://#diff-df935d7cee4a2527f26a7b1efb7f5e0ee609fbef0f795a4806fb5957d8d2896bR239-R295) [[2]](diffhunk://#diff-df935d7cee4a2527f26a7b1efb7f5e0ee609fbef0f795a4806fb5957d8d2896bR159-R161)
* Updated imports in `output.py` to support new unit handling and calculations for additional metrics.