### PR TITLE
Add per-process and per-call statistics for time and size metrics

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Welcome to DFAnalyzer's documentation!
    overview
    getting-started
    configuration
+   metrics
    interactive-analysis
    tools
 

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -1,0 +1,390 @@
+.. _metrics:
+
+Metrics Reference
+=================
+
+DFAnalyzer produces flat views — pandas DataFrames where each row represents a group (e.g., a process, a time range, a file) and each column is a metric. This document explains how to read column names, what each metric family measures, and how to use the two-track statistics system for diagnosing parallel I/O issues.
+
+.. contents::
+   :local:
+   :depth: 2
+
+Column Naming Convention
+------------------------
+
+Every flat view column follows a structured naming pattern::
+
+   {layer}_{metric_family}_{statistic}
+
+For example::
+
+   posix_read_time_proc_mean
+   │     │    │    │    └── statistic: mean across processes
+   │     │    │    └─────── track: per-process (proc)
+   │     │    └──────────── base metric: time (seconds)
+   │     └───────────────── derived metric: read operations
+   └─────────────────────── layer: posix
+
+**Layer** is the execution layer (e.g., ``posix``, ``reader``, ``epoch``, ``compute``). Layers are defined by the preset configuration and form a hierarchy.
+
+**Metric family** is the optional derived metric prefix (e.g., ``read_``, ``write_``, ``data_``, ``metadata_``, ``open_``, ``close_``, ``seek_``, ``stat_``, ``sync_``). When absent, the metric covers all operations in that layer.
+
+**Base metric** is one of: ``time`` (seconds), ``count`` (number of operations), ``size`` (bytes).
+
+**Track and statistic** identify which distribution the value describes and the aggregation function. See :ref:`two-track-statistics` for details.
+
+
+.. _two-track-statistics:
+
+Two-Track Statistics: Proc vs Call
+----------------------------------
+
+DFAnalyzer computes two parallel sets of statistics for ``time`` and ``size`` metrics, each answering a different question about the data.
+
+Per-Process Statistics (``proc``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Question**: How are process-level totals distributed across processes?
+
+The ``_proc_`` statistics describe the distribution of **per-process aggregate values**. When creating a view (e.g., grouped by ``time_range``), DFAnalyzer first computes each process's total for that group, then takes the min, max, mean, and standard deviation across processes.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Column suffix
+     - Meaning
+   * - ``time_proc_min``
+     - Minimum per-process total time across all processes in this group
+   * - ``time_proc_max``
+     - Maximum per-process total time (the **bottleneck** process)
+   * - ``time_proc_mean``
+     - Average per-process total time
+   * - ``time_proc_std``
+     - Standard deviation of per-process totals (measures **inter-process imbalance**)
+
+Per-Call Statistics (``call``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Question**: How are individual call durations/sizes distributed?
+
+The ``_call_`` statistics describe the distribution of **individual trace events** (calls) within each group. These are computed from sum-of-squares support columns, allowing exact aggregation across processes without storing every individual value.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Column suffix
+     - Meaning
+   * - ``time_call_min``
+     - Minimum individual call duration across all calls in this group
+   * - ``time_call_max``
+     - Maximum individual call duration (the **slowest single call**)
+   * - ``time_call_mean``
+     - Average individual call duration
+   * - ``time_call_std``
+     - Standard deviation of individual call durations (measures **tail latency**)
+
+Why Two Tracks?
+~~~~~~~~~~~~~~~
+
+Consider an 8-process job where each process makes 1,000 I/O calls:
+
+- ``time_proc_mean = 0.33s``, ``time_proc_std = 0.25s`` — process totals vary moderately. Some processes do more I/O than others.
+- ``time_call_mean = 0.012s``, ``time_call_std = 0.051s`` — individual calls average 12ms, but with a standard deviation of 51ms. The coefficient of variation (std/mean ≈ 4x) indicates heavy-tailed call latency.
+
+The process-level view tells you about **load balance**. The call-level view tells you about **individual call behavior**. A system can be well-balanced across processes yet have problematic tail latency on individual calls — or vice versa. You need both to diagnose effectively.
+
+.. note::
+
+   **Why no proc/call split for** ``count``? Each raw trace event has ``count=1``, so ``count_call_std`` would always be 0 — every "call" has the same count. The ``count`` metric only has aggregate statistics (``count_sum``, ``count_proc_min``, ``count_proc_max``, etc.).
+
+
+Aggregate Metrics
+-----------------
+
+These are the raw aggregated values before any derived ratios.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Column suffix
+     - Meaning
+   * - ``time_sum``
+     - Total time across all processes and calls in the group
+   * - ``count_sum``
+     - Total number of operations
+   * - ``size_sum``
+     - Total bytes transferred
+
+
+Derived Performance Metrics
+---------------------------
+
+Computed from the base metrics above. These are always per-process statistics (derived from the aggregated per-process values).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Column suffix
+     - Meaning
+   * - ``bw_sum``
+     - Bandwidth (``size_sum / time_sum``), bytes/second
+   * - ``bw_proc_{min,max,mean,std}``
+     - Per-process bandwidth distribution
+   * - ``ops_sum``
+     - Operations per second (``count_sum / time_sum``)
+   * - ``ops_proc_{min,max,mean,std}``
+     - Per-process ops/sec distribution
+   * - ``intensity_sum``
+     - I/O intensity (``count_sum / size_sum``), operations/byte
+   * - ``intensity_proc_{min,max,mean,std}``
+     - Per-process intensity distribution
+
+.. note::
+
+   ``bw``, ``ops``, and ``intensity`` are only meaningful when their denominators are non-zero. Columns are set to ``NA`` when the denominator is zero or when size is not applicable (e.g., non-POSIX layers).
+
+
+Fractional Metrics
+------------------
+
+Fractional metrics express a group's share of a total. These are where the proc/call distinction becomes most actionable.
+
+``frac_total`` — Share of Column Total
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Column suffix
+     - Meaning
+   * - ``count_frac_total``
+     - This row's ``count_sum`` as a fraction of the column total
+   * - ``time_proc_frac_total``
+     - This row's share of **bottleneck process time** across all rows
+   * - ``time_call_frac_total``
+     - This row's share of **aggregate time** across all rows
+   * - ``size_proc_frac_total``
+     - This row's share of **bottleneck process data volume** across all rows
+   * - ``size_call_frac_total``
+     - This row's share of **aggregate data volume** across all rows
+
+**How the tracks differ for non-process views:**
+
+In a ``proc_name`` view (process-based), both tracks use ``time_sum`` and produce identical values. In a ``time_range`` or ``file_name`` view (non-process-based):
+
+- ``proc_frac_total`` uses ``time_proc_max`` (the bottleneck process's value per group)
+- ``call_frac_total`` uses ``time_sum`` (the aggregate across all processes per group)
+
+**Interpreting divergence:**
+
+If ``time_proc_frac_total`` is much higher than ``time_call_frac_total`` for a particular time range, the bottleneck process is disproportionately loaded during that period — a straggler signal. If the values are similar everywhere, the workload is well-balanced.
+
+``frac_boundary`` — Share of Top-Layer Time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These express a layer's time relative to the top layer (the "boundary" layer, typically ``app`` or ``epoch``).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Column suffix
+     - Meaning
+   * - ``time_proc_frac_{boundary}``
+     - Layer's bottleneck time / boundary layer's bottleneck time
+   * - ``time_call_frac_{boundary}``
+     - Layer's aggregate time / boundary layer's aggregate time
+
+For example, ``posix_time_proc_frac_epoch = 0.8`` means the bottleneck process spends 80% of its epoch time in POSIX I/O.
+
+**Interpreting divergence:**
+
+If ``posix_time_proc_frac_epoch = 0.8`` but ``posix_time_call_frac_epoch = 0.4``, the straggler is spending twice as much of its time in POSIX I/O compared to the fleet average — a strong signal that the straggler's bottleneck is I/O-specific.
+
+``frac_parent`` — Share of Parent Layer Time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These express a child layer's time relative to its parent in the layer hierarchy.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Column suffix
+     - Meaning
+   * - ``time_proc_frac_parent``
+     - Child's bottleneck time / parent's bottleneck time
+   * - ``time_call_frac_parent``
+     - Child's aggregate time / parent's aggregate time
+
+``ops_slope`` and ``ops_percentile``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Column suffix
+     - Meaning
+   * - ``ops_slope``
+     - Ratio of ``time_proc_frac_total / count_frac_total``. Values > 1 mean this group uses more than its share of time relative to its share of operations — indicating slower-than-average operations.
+   * - ``ops_percentile``
+     - Percentile rank of ``ops_slope`` within the view. High percentiles indicate groups with disproportionately slow operations.
+
+
+Cross-Layer Metrics
+-------------------
+
+Cross-layer metrics quantify relationships between layers in the hierarchy. They are computed by ``set_cross_layer_metrics`` and produce both proc and call variants.
+
+Overhead Metrics (``o_``)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Overhead is the time a parent layer spends in its own logic, excluding time attributed to child layers.
+
+::
+
+   o_{layer}_time = max(layer_time - sum(child_times), 0)
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Column
+     - Meaning
+   * - ``o_{layer}_{time_metric}``
+     - Overhead time value (base column). For proc track, ``time_metric`` is ``time_proc_max`` (non-process views) or ``time_sum`` (process views). For call track, always ``time_sum``.
+   * - ``o_{layer}_time_proc_frac_self``
+     - Overhead as fraction of the layer's own bottleneck time
+   * - ``o_{layer}_time_call_frac_self``
+     - Overhead as fraction of the layer's own aggregate time
+   * - ``o_{layer}_time_proc_frac_{boundary}``
+     - Overhead as fraction of top-layer bottleneck time
+   * - ``o_{layer}_time_call_frac_{boundary}``
+     - Overhead as fraction of top-layer aggregate time
+   * - ``o_{layer}_time_proc_frac_total``
+     - This row's share of total overhead across all rows (proc track)
+   * - ``o_{layer}_time_call_frac_total``
+     - This row's share of total overhead across all rows (call track)
+
+**Interpreting divergence:**
+
+If ``o_epoch_time_proc_frac_self`` is high but ``o_epoch_time_call_frac_self`` is low, the bottleneck process has more overhead than typical. This points to a process-specific issue (e.g., the straggler is doing extra work in the epoch's own logic rather than in its child layers).
+
+Unoverlapped Metrics (``u_``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unoverlapped time measures how much of an async layer's time does **not** overlap with compute. This quantifies I/O time that is actually stalling the application (cannot be hidden behind computation).
+
+::
+
+   u_{layer}_time = max(layer_time - compute_time, 0)
+
+These metrics are only produced for layers marked as ``async_layers`` in the preset configuration, and only when a ``compute`` layer exists.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 60
+
+   * - Column
+     - Meaning
+   * - ``u_{layer}_{time_metric}``
+     - Unoverlapped time value (base column)
+   * - ``u_{layer}_time_proc_frac_self``
+     - Unoverlapped time as fraction of layer's own bottleneck time
+   * - ``u_{layer}_time_call_frac_self``
+     - Unoverlapped time as fraction of layer's own aggregate time
+   * - ``u_{layer}_time_proc_frac_{boundary}``
+     - Unoverlapped time as fraction of top-layer bottleneck time
+   * - ``u_{layer}_time_call_frac_{boundary}``
+     - Unoverlapped time as fraction of top-layer aggregate time
+   * - ``u_{layer}_time_proc_frac_parent``
+     - Unoverlapped time as fraction of parent layer's bottleneck time
+   * - ``u_{layer}_time_call_frac_parent``
+     - Unoverlapped time as fraction of parent layer's aggregate time
+   * - ``u_{layer}_time_proc_frac_total``
+     - This row's share of total unoverlapped time (proc track)
+   * - ``u_{layer}_time_call_frac_total``
+     - This row's share of total unoverlapped time (call track)
+
+**Interpreting divergence:**
+
+If ``u_posix_time_proc_frac_self = 0.9`` but ``u_posix_time_call_frac_self = 0.5``, the bottleneck process has 90% unoverlapped I/O while the average is 50%. The straggler is not benefiting from compute overlap — possibly because its I/O is serialized or its compute phase is shorter.
+
+
+Other Metric Families
+---------------------
+
+Size Bins
+~~~~~~~~~
+
+Columns matching ``size_bin_{range}_sum`` count how many operations fall into each transfer size bucket. These are useful for characterizing the I/O size distribution.
+
+The bins are::
+
+   0-4KiB, 4-16KiB, 16-64KiB, 64-256KiB, 256KiB-1MiB,
+   1-4MiB, 4-16MiB, 16-64MiB, 64-256MiB, 256MiB-1GiB,
+   1-4GiB, 4GiB+
+
+Unique Counts
+~~~~~~~~~~~~~
+
+Columns ending in ``_nunique`` count distinct values within a group:
+
+- ``file_name_nunique`` — number of distinct files accessed
+- ``proc_name_nunique`` — number of distinct processes (in non-process views)
+- ``time_range_nunique`` — number of distinct time ranges spanned
+
+
+Interpretation Guide
+--------------------
+
+Diagnosing Load Imbalance
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Compare ``time_proc_std`` against ``time_proc_mean``. A high coefficient of variation (std/mean > 0.5) suggests significant inter-process imbalance.
+
+In non-process views, compare ``time_proc_frac_total`` vs ``time_call_frac_total``:
+
+- **Proc > Call**: The bottleneck process is disproportionately loaded here — straggler behavior
+- **Proc ≈ Call**: Workload is evenly distributed
+- **Proc < Call**: Many processes contribute aggregate time, but no single one dominates
+
+Diagnosing Tail Latency
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Compare ``time_call_std`` against ``time_call_mean``. A coefficient of variation > 2x indicates heavy-tailed call durations — some individual I/O calls are much slower than average. This is common with:
+
+- Shared file contention
+- Metadata-heavy workloads
+- Network filesystem latency spikes
+
+Diagnosing Compute/I/O Overlap Issues
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Look at ``u_{layer}_time_proc_frac_self`` (or the call variant):
+
+- **Near 1.0**: Almost no overlap with compute — I/O is fully stalling the application
+- **Near 0.0**: I/O is well-hidden behind compute
+- **Proc much higher than call**: The bottleneck process specifically fails to overlap I/O with compute
+
+Diagnosing Layer-Specific Bottlenecks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``time_proc_frac_{boundary}`` to identify which layers consume the most time:
+
+1. Start with the top-level boundary fractions to find the dominant layer
+2. Use ``time_proc_frac_parent`` to drill down into child layers
+3. Use ``o_{layer}_time_proc_frac_self`` to see how much time the parent spends in its own logic vs delegating to children
+
+Compare proc vs call variants at each level to determine whether the bottleneck is straggler-specific or systemic.
+
+Process-Based vs Non-Process Views
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The proc/call distinction only produces different values in **non-process-based views** (``time_range``, ``file_name``). In process-based views (``proc_name``), both tracks use ``time_sum`` and produce identical values. This is by design: when the view is already per-process, "bottleneck process" and "aggregate" are the same concept.

--- a/python/dftracer/analyzer/analysis_utils.py
+++ b/python/dftracer/analyzer/analysis_utils.py
@@ -23,6 +23,71 @@ from .constants import (
 logger = structlog.get_logger()
 
 
+
+def build_view_rename_map(columns):
+    """Build a column rename dict for view-level statistics.
+
+    Renames per-process stats (e.g., time_min → time_proc_min) and
+    fixes double-suffixed per-call stats (e.g., time_call_min_min → time_call_min).
+    """
+    rename_map = {}
+    for col in columns:
+        if col.endswith("_call_min_min"):
+            rename_map[col] = col[: -len("_min")]
+        elif col.endswith("_call_max_max"):
+            rename_map[col] = col[: -len("_max")]
+        elif col.endswith("_min") and not col.endswith("_call_min"):
+            rename_map[col] = col[: -len("_min")] + "_proc_min"
+        elif col.endswith("_max") and not col.endswith("_call_max"):
+            rename_map[col] = col[: -len("_max")] + "_proc_max"
+        elif col.endswith("_mean"):
+            rename_map[col] = col[: -len("_mean")] + "_proc_mean"
+        elif col.endswith("_std"):
+            rename_map[col] = col[: -len("_std")] + "_proc_std"
+    return rename_map
+
+
+def derive_call_stats(df: pd.DataFrame) -> pd.DataFrame:
+    """Derive per-call mean and std from sum-of-squares support columns.
+
+    For each column ending in '_sq_sum', computes:
+      - {prefix}_call_mean = sum / count
+      - {prefix}_call_std  = sqrt(sq/n - mean^2)
+    Then drops the support column.
+    """
+    sq_cols = [c for c in df.columns if c.endswith("_sq_sum")]
+    if not sq_cols:
+        return df
+    df = df.copy()
+    for sq_col in sq_cols:
+        prefix = sq_col[: -len("_sq_sum")]
+        sum_col = f"{prefix}_sum"
+
+        # Determine the count column for this metric family
+        if prefix in ("time", "size"):
+            count_col = "count_sum"
+        elif prefix.endswith("_time"):
+            count_col = prefix[: -len("time")] + "count_sum"
+        elif prefix.endswith("_size"):
+            count_col = prefix[: -len("size")] + "count_sum"
+        else:
+            continue
+
+        if sum_col not in df.columns or count_col not in df.columns:
+            continue
+
+        n = df[count_col].astype("Float64")
+        s = df[sum_col].astype("Float64")
+        sq = df[sq_col].astype("Float64")
+        mean = s / n
+        var = (sq / n - mean**2).clip(lower=0)
+        df[f"{prefix}_call_mean"] = mean
+        df[f"{prefix}_call_std"] = var ** 0.5
+
+    df = df.drop(columns=sq_cols)
+    return df
+
+
 def fix_dtypes(df: pd.DataFrame, time_sliced: bool = False):
     if df.empty:
         return df

--- a/python/dftracer/analyzer/analyzer.py
+++ b/python/dftracer/analyzer/analyzer.py
@@ -13,6 +13,8 @@ from omegaconf import OmegaConf
 from typing import Callable, Dict, List, Optional, Tuple
 
 from .analysis_utils import (
+    build_view_rename_map,
+    derive_call_stats,
     fix_dtypes,
     fix_std_cols,
     set_file_dir,
@@ -947,12 +949,12 @@ class Analyzer(abc.ABC):
                         continue
                     view_type = view_key[-1]
                     top_layer = list(self.preset.layer_defs)[0]
-                    time_suffix = "time_sum" if self.is_view_process_based(view_key) else "time_max"
+                    time_proc_suffix = "time_sum" if self.is_view_process_based(view_key) else "time_proc_max"
                     with log_block("calculate_metric_boundary", view_key=view_key):
-                        time_boundary = flat_views[view_key][f"{top_layer}_{time_suffix}"].sum()
+                        time_boundary = flat_views[view_key][f"{top_layer}_{time_proc_suffix}"].sum()
                         metric_boundaries.setdefault(view_type, {})
                         for layer in self.preset.layer_defs:
-                            metric_boundaries[view_type][f"{layer}_{time_suffix}"] = time_boundary
+                            metric_boundaries[view_type][f"{layer}_{time_proc_suffix}"] = time_boundary
                     with log_block("process_flat_view", view_key=view_key):
                         # Process flat views to compute metrics and scores
                         flat_views[view_key] = self._process_flat_view(
@@ -998,9 +1000,25 @@ class Analyzer(abc.ABC):
         # Build agg_dict
         bin_cols = [col for col in traces.columns if "_bin_" in col]
         view_types_diff = list(set(VIEW_TYPES).difference(view_types))
+        # Pre-compute alias columns for per-call statistics
+        traces = traces.assign(
+            time_sq=traces["time"] ** 2,
+            size_sq=traces["size"] ** 2,
+            time_call_min=traces["time"],
+            time_call_max=traces["time"],
+            size_call_min=traces["size"],
+            size_call_max=traces["size"],
+        )
         hlm_agg = dict(HLM_AGG)
         hlm_agg.update({col: "sum" for col in bin_cols})
         hlm_agg.update({col: unique_set() for col in view_types_diff})
+        # Per-call support columns
+        hlm_agg["time_sq"] = "sum"
+        hlm_agg["size_sq"] = "sum"
+        hlm_agg["time_call_min"] = "min"
+        hlm_agg["time_call_max"] = "max"
+        hlm_agg["size_call_min"] = "min"
+        hlm_agg["size_call_max"] = "max"
         hlm = (
             traces.groupby(hlm_groupby)
             .agg(hlm_agg, split_out=math.ceil(math.sqrt(traces.npartitions)))
@@ -1038,7 +1056,12 @@ class Analyzer(abc.ABC):
                 if any(map(col.endswith, view_types_diff)):
                     main_view_agg[col] = unique_set_flatten()
                 elif col not in HLM_EXTRA_COLS:
-                    main_view_agg[col] = "sum"
+                    if col.endswith("_call_min"):
+                        main_view_agg[col] = "min"
+                    elif col.endswith("_call_max"):
+                        main_view_agg[col] = "max"
+                    else:
+                        main_view_agg[col] = "sum"
         with log_block("compute_main_view", layer=layer):
             main_view = (
                 hlm.groupby(list(view_types))
@@ -1073,6 +1096,12 @@ class Analyzer(abc.ABC):
                     view_agg[col] = [unique_set_flatten()]
                 elif col in it.chain.from_iterable(self.logical_views.values()):
                     view_agg[col] = [unique_set_flatten()]
+                elif col.endswith("_sq"):
+                    view_agg[col] = ["sum"]
+                elif col.endswith("_call_min"):
+                    view_agg[col] = ["min"]
+                elif col.endswith("_call_max"):
+                    view_agg[col] = ["max"]
                 elif pd.api.types.is_numeric_dtype(records[col].dtype):
                     view_agg[col] = [
                         "sum",
@@ -1101,14 +1130,26 @@ class Analyzer(abc.ABC):
         with log_block("pre_grouping", layer=layer, view_key=view_key):
             pre_view = records.reset_index()
             if view_type != COL_PROC_NAME:
-                pre_view = pre_view.groupby([view_type, COL_PROC_NAME]).sum().reset_index()
+                pre_agg = {}
+                for col in pre_view.columns:
+                    if col in (view_type, COL_PROC_NAME):
+                        continue
+                    if col.endswith("_call_min"):
+                        pre_agg[col] = "min"
+                    elif col.endswith("_call_max"):
+                        pre_agg[col] = "max"
+                    else:
+                        pre_agg[col] = "sum"
+                pre_view = pre_view.groupby([view_type, COL_PROC_NAME]).agg(pre_agg).reset_index()
 
         with log_block("groupby_agg_pipeline", layer=layer, view_key=view_key):
             view = pre_view.groupby([view_type]).agg(view_agg).replace(0, pd.NA)
         with log_block("finalize", layer=layer, view_key=view_key):
             view = flatten_column_names(view)
+            view = view.rename(columns=build_view_rename_map(view.columns))
             view = (
-                view.map_partitions(set_unique_counts, layer=layer)
+                view.map_partitions(derive_call_stats)
+                .map_partitions(set_unique_counts, layer=layer)
                 .map_partitions(fix_dtypes, time_sliced=self.time_sliced)
                 .persist()
             )
@@ -1153,13 +1194,13 @@ class Analyzer(abc.ABC):
     def _set_additional_metrics(self, view: pd.DataFrame, view_key: ViewKey, epsilon=1e-9) -> pd.DataFrame:
         view_type = view_key[-1]
         is_view_process_based = self.is_view_process_based(view_key)
-        time_metric = "time_sum" if is_view_process_based else "time_max"
+        time_proc_metric = "time_sum" if is_view_process_based else "time_proc_max"
         view_additional_metrics = (self.preset.additional_metrics or {}).get(view_type, {})
         for metric, eval_condition in view_additional_metrics.items():
             eval_condition = eval_condition.format(
                 epsilon=epsilon,
                 time_interval=self.time_granularity,
-                time_metric=time_metric,
+                time_metric=time_proc_metric,
             )
             view = view.eval(f"{metric} = {eval_condition}")
             numerator_denominators = extract_numerator_and_denominators(eval_condition)

--- a/python/dftracer/analyzer/metrics.py
+++ b/python/dftracer/analyzer/metrics.py
@@ -86,8 +86,10 @@ def set_view_metrics(
     df = df.copy()
 
     count_metric = 'count_sum'
-    size_metric = 'size_sum'
-    time_metric = 'time_sum' if is_view_process_based else 'time_max'
+    size_proc_metric = 'size_sum' if is_view_process_based else 'size_proc_max'
+    size_call_metric = 'size_sum'
+    time_proc_metric = 'time_sum' if is_view_process_based else 'time_proc_max'
+    time_call_metric = 'time_sum'
 
     view_metrics = list(set(df.columns.tolist()))
     new_metrics: Dict[str, pd.Series] = {}
@@ -101,28 +103,47 @@ def set_view_metrics(
                 new_metrics[count_frac_total_col] = df[count_col] / count_sum
             else:
                 new_metrics[count_frac_total_col] = pd.Series(pd.NA, index=df.index, dtype='Float64')
-        elif metric.endswith(size_metric):
+        elif metric.endswith(size_proc_metric):
             size_col = metric
-            size_frac_total_col = metric.replace(size_metric, 'size_frac_total')
-            size_sum = df[size_col].sum()
-            if size_sum > 0:
-                new_metrics[size_frac_total_col] = df[size_col] / size_sum
+            size_proc_frac_total_col = metric.replace(size_proc_metric, 'size_proc_frac_total')
+            size_total = df[size_col].sum()
+            if size_total > 0:
+                new_metrics[size_proc_frac_total_col] = df[size_col] / size_total
             else:
-                new_metrics[size_frac_total_col] = pd.Series(pd.NA, index=df.index, dtype='Float64')
-        elif metric.endswith(time_metric):
+                new_metrics[size_proc_frac_total_col] = pd.Series(pd.NA, index=df.index, dtype='Float64')
+        elif metric.endswith(time_proc_metric):
             time_col = metric
-            time_frac_total_col = metric.replace(time_metric, 'time_frac_total')
-            time_sum = df[time_col].sum()
-            if time_sum > 0:
-                new_metrics[time_frac_total_col] = df[time_col] / time_sum
+            time_proc_frac_total_col = metric.replace(time_proc_metric, 'time_proc_frac_total')
+            time_total = df[time_col].sum()
+            if time_total > 0:
+                new_metrics[time_proc_frac_total_col] = df[time_col] / time_total
             else:
-                new_metrics[time_frac_total_col] = pd.Series(pd.NA, index=df.index, dtype='Float64')
+                new_metrics[time_proc_frac_total_col] = pd.Series(pd.NA, index=df.index, dtype='Float64')
 
-    count_time_frac_metric_pairs = _find_metric_pairs(list(new_metrics.keys()), 'count_frac_total', 'time_frac_total')
-    for count_frac_total_col, time_frac_total_col in count_time_frac_metric_pairs:
+    # Compute call_frac_total metrics (always from *_sum, regardless of view type)
+    for metric in view_metrics:
+        if metric.endswith(size_call_metric):
+            size_call_col = metric
+            size_call_frac_total_col = metric.replace(size_call_metric, 'size_call_frac_total')
+            size_call_total = df[size_call_col].sum()
+            if size_call_total > 0:
+                new_metrics[size_call_frac_total_col] = df[size_call_col] / size_call_total
+            else:
+                new_metrics[size_call_frac_total_col] = pd.Series(pd.NA, index=df.index, dtype='Float64')
+        elif metric.endswith(time_call_metric):
+            time_call_col = metric
+            time_call_frac_total_col = metric.replace(time_call_metric, 'time_call_frac_total')
+            time_call_total = df[time_call_col].sum()
+            if time_call_total > 0:
+                new_metrics[time_call_frac_total_col] = df[time_call_col] / time_call_total
+            else:
+                new_metrics[time_call_frac_total_col] = pd.Series(pd.NA, index=df.index, dtype='Float64')
+
+    count_time_proc_frac_metric_pairs = _find_metric_pairs(list(new_metrics.keys()), 'count_frac_total', 'time_proc_frac_total')
+    for count_frac_total_col, time_proc_frac_total_col in count_time_proc_frac_metric_pairs:
         ops_percentile_col = count_frac_total_col.replace('count_frac_total', 'ops_percentile')
         ops_slope_col = count_frac_total_col.replace('count_frac_total', 'ops_slope')
-        ops_slope = new_metrics[time_frac_total_col] / new_metrics[count_frac_total_col]
+        ops_slope = new_metrics[time_proc_frac_total_col] / new_metrics[count_frac_total_col]
         ops_slope = ops_slope.replace([np.inf, -np.inf], pd.NA)
         new_metrics[ops_percentile_col] = ops_slope.rank(pct=True)
         new_metrics[ops_slope_col] = ops_slope
@@ -147,82 +168,82 @@ def set_cross_layer_metrics(
     is_view_process_based: bool,
     time_boundary_layer: str,
 ) -> pd.DataFrame:
-    time_metric = 'time_sum' if is_view_process_based else 'time_max'
-    compute_time_metric = f"compute_{time_metric}"
-    time_boundary_metric = f"{time_boundary_layer}_{time_metric}"
+    time_proc_metric = 'time_sum' if is_view_process_based else 'time_proc_max'
+    compute_time_proc_metric = f"compute_{time_proc_metric}"
+    time_proc_boundary_metric = f"{time_boundary_layer}_{time_proc_metric}"
 
     # Collect new columns and assign them in batch to avoid fragmentation warnings
     x_layer_metrics: Dict[str, pd.Series] = {}
 
     # Set relational time metrics for layers
     for layer in layers:
-        layer_time = df[f"{layer}_{time_metric}"]
+        layer_time = df[f"{layer}_{time_proc_metric}"]
 
-        time_frac_boundary_col = f"{layer}_time_frac_{time_boundary_layer}"
-        x_layer_metrics[time_frac_boundary_col] = layer_time / df[time_boundary_metric]
+        time_proc_frac_boundary_col = f"{layer}_time_proc_frac_{time_boundary_layer}"
+        x_layer_metrics[time_proc_frac_boundary_col] = layer_time / df[time_proc_boundary_metric]
 
         child_layers = [child for child, parent in layer_deps.items() if parent == layer]
         if not child_layers:
             continue
 
-        o_time_col = f"o_{layer}_{time_metric}"
-        o_time_frac_boundary_col = f"o_{layer}_time_frac_{time_boundary_layer}"
-        o_time_frac_self_col = f"o_{layer}_time_frac_self"
-        o_time_frac_total_col = o_time_col.replace(time_metric, 'time_frac_total')
+        o_time_col = f"o_{layer}_{time_proc_metric}"
+        o_time_proc_frac_boundary_col = f"o_{layer}_time_proc_frac_{time_boundary_layer}"
+        o_time_proc_frac_self_col = f"o_{layer}_time_proc_frac_self"
+        o_time_proc_frac_total_col = o_time_col.replace(time_proc_metric, 'time_proc_frac_total')
 
-        child_time_sum = sum(df[f"{child}_{time_metric}"].fillna(0) for child in child_layers)
+        child_time_sum = sum(df[f"{child}_{time_proc_metric}"].fillna(0) for child in child_layers)
         o_time = np.maximum(layer_time - child_time_sum, 0)
         o_time_sum = o_time.sum()
 
         o_time_series = pd.array(o_time, dtype='Float64')
         x_layer_metrics[o_time_col] = o_time_series
-        x_layer_metrics[o_time_frac_boundary_col] = o_time_series / df[time_boundary_metric]
-        x_layer_metrics[o_time_frac_self_col] = o_time_series / layer_time
-        x_layer_metrics[o_time_frac_total_col] = pd.NA
+        x_layer_metrics[o_time_proc_frac_boundary_col] = o_time_series / df[time_proc_boundary_metric]
+        x_layer_metrics[o_time_proc_frac_self_col] = o_time_series / layer_time
+        x_layer_metrics[o_time_proc_frac_total_col] = pd.NA
         if o_time_sum > 0:
-            x_layer_metrics[o_time_frac_total_col] = o_time_series / o_time_sum
+            x_layer_metrics[o_time_proc_frac_total_col] = o_time_series / o_time_sum
 
         layer_has_time = layer_time.sum() > 0
         for child_layer in child_layers:
-            time_frac_parent_col = f"{child_layer}_time_frac_parent"
-            x_layer_metrics[time_frac_parent_col] = pd.NA
+            time_proc_frac_parent_col = f"{child_layer}_time_proc_frac_parent"
+            x_layer_metrics[time_proc_frac_parent_col] = pd.NA
             if layer_has_time:
-                x_layer_metrics[time_frac_parent_col] = df[f"{child_layer}_{time_metric}"] / layer_time
+                x_layer_metrics[time_proc_frac_parent_col] = df[f"{child_layer}_{time_proc_metric}"] / layer_time
 
     # Set relational time metrics for derived metrics
     for layer in derived_metrics:
         for dm in derived_metrics[layer]:
             dm_col = f"{layer}_{dm}"
-            dm_time_col = f"{dm_col}_{time_metric}"
+            dm_time_col = f"{dm_col}_{time_proc_metric}"
 
             if dm_time_col not in df.columns:
                 continue
 
-            dm_time_frac_boundary_col = f"{dm_col}_time_frac_{time_boundary_layer}"
-            dm_time_frac_parent_col = f"{dm_col}_time_frac_parent"
-            dm_time_frac_total_col = f"{dm_col}_time_frac_total"
+            dm_time_proc_frac_boundary_col = f"{dm_col}_time_proc_frac_{time_boundary_layer}"
+            dm_time_proc_frac_parent_col = f"{dm_col}_time_proc_frac_parent"
+            dm_time_proc_frac_total_col = f"{dm_col}_time_proc_frac_total"
 
             dm_time = df[dm_time_col]
             dm_time_sum = dm_time.sum()
 
-            x_layer_metrics[dm_time_frac_boundary_col] = dm_time / df[time_boundary_metric]
-            x_layer_metrics[dm_time_frac_parent_col] = dm_time / df[f"{layer}_{time_metric}"]
-            x_layer_metrics[dm_time_frac_total_col] = pd.NA
+            x_layer_metrics[dm_time_proc_frac_boundary_col] = dm_time / df[time_proc_boundary_metric]
+            x_layer_metrics[dm_time_proc_frac_parent_col] = dm_time / df[f"{layer}_{time_proc_metric}"]
+            x_layer_metrics[dm_time_proc_frac_total_col] = pd.NA
 
             if dm_time_sum > 0:
-                x_layer_metrics[dm_time_frac_total_col] = dm_time / dm_time_sum
+                x_layer_metrics[dm_time_proc_frac_total_col] = dm_time / dm_time_sum
 
     # Set unoverlapped times if there is compute time
-    if compute_time_metric in df.columns:
-        compute_time = df[compute_time_metric].fillna(0).astype('Float64')
+    if compute_time_proc_metric in df.columns:
+        compute_time = df[compute_time_proc_metric].fillna(0).astype('Float64')
         # Set unoverlapped time metrics
         for async_layer in async_layers:
-            time_col = f"{async_layer}_{time_metric}"
+            time_col = f"{async_layer}_{time_proc_metric}"
 
             u_time_col = f"u_{time_col}"
-            u_time_frac_boundary_col = f"u_{async_layer}_time_frac_{time_boundary_layer}"
-            u_time_frac_self_col = f"u_{async_layer}_time_frac_self"
-            u_time_frac_total_col = f"u_{async_layer}_time_frac_total"
+            u_time_proc_frac_boundary_col = f"u_{async_layer}_time_proc_frac_{time_boundary_layer}"
+            u_time_proc_frac_self_col = f"u_{async_layer}_time_proc_frac_self"
+            u_time_proc_frac_total_col = f"u_{async_layer}_time_proc_frac_total"
 
             layer_time = df[time_col]
             u_time = (layer_time - compute_time).clip(lower=0).astype('Float64')
@@ -230,16 +251,16 @@ def set_cross_layer_metrics(
 
             u_time_series = pd.array(u_time, dtype='Float64')
             x_layer_metrics[u_time_col] = u_time_series
-            x_layer_metrics[u_time_frac_self_col] = u_time_series / layer_time
-            x_layer_metrics[u_time_frac_boundary_col] = u_time_series / df[time_boundary_metric]
-            x_layer_metrics[u_time_frac_total_col] = pd.NA
+            x_layer_metrics[u_time_proc_frac_self_col] = u_time_series / layer_time
+            x_layer_metrics[u_time_proc_frac_boundary_col] = u_time_series / df[time_proc_boundary_metric]
+            x_layer_metrics[u_time_proc_frac_total_col] = pd.NA
             if u_time_sum > 0:
-                x_layer_metrics[u_time_frac_total_col] = u_time_series / u_time_sum
+                x_layer_metrics[u_time_proc_frac_total_col] = u_time_series / u_time_sum
 
             parent_layer = layer_deps.get(async_layer)
             if parent_layer:
-                u_time_frac_parent_col = f"u_{async_layer}_time_frac_parent"
-                x_layer_metrics[u_time_frac_parent_col] = u_time_series / df[f"{parent_layer}_{time_metric}"]
+                u_time_proc_frac_parent_col = f"u_{async_layer}_time_proc_frac_parent"
+                x_layer_metrics[u_time_proc_frac_parent_col] = u_time_series / df[f"{parent_layer}_{time_proc_metric}"]
 
     if x_layer_metrics:
         x_layer_metrics_df = pd.DataFrame(x_layer_metrics, index=df.index)

--- a/python/dftracer/analyzer/metrics.py
+++ b/python/dftracer/analyzer/metrics.py
@@ -169,98 +169,154 @@ def set_cross_layer_metrics(
     time_boundary_layer: str,
 ) -> pd.DataFrame:
     time_proc_metric = 'time_sum' if is_view_process_based else 'time_proc_max'
+    time_call_metric = 'time_sum'
     compute_time_proc_metric = f"compute_{time_proc_metric}"
+    compute_time_call_metric = f"compute_{time_call_metric}"
     time_proc_boundary_metric = f"{time_boundary_layer}_{time_proc_metric}"
+    time_call_boundary_metric = f"{time_boundary_layer}_{time_call_metric}"
 
     # Collect new columns and assign them in batch to avoid fragmentation warnings
     x_layer_metrics: Dict[str, pd.Series] = {}
 
     # Set relational time metrics for layers
     for layer in layers:
-        layer_time = df[f"{layer}_{time_proc_metric}"]
+        layer_time_proc = df[f"{layer}_{time_proc_metric}"]
+        layer_time_call = df[f"{layer}_{time_call_metric}"]
 
+        # Proc: frac_boundary
         time_proc_frac_boundary_col = f"{layer}_time_proc_frac_{time_boundary_layer}"
-        x_layer_metrics[time_proc_frac_boundary_col] = layer_time / df[time_proc_boundary_metric]
+        x_layer_metrics[time_proc_frac_boundary_col] = layer_time_proc / df[time_proc_boundary_metric]
+        # Call: frac_boundary
+        time_call_frac_boundary_col = f"{layer}_time_call_frac_{time_boundary_layer}"
+        x_layer_metrics[time_call_frac_boundary_col] = layer_time_call / df[time_call_boundary_metric]
 
         child_layers = [child for child, parent in layer_deps.items() if parent == layer]
         if not child_layers:
             continue
 
-        o_time_col = f"o_{layer}_{time_proc_metric}"
+        # Proc: overhead
+        o_time_proc_col = f"o_{layer}_{time_proc_metric}"
         o_time_proc_frac_boundary_col = f"o_{layer}_time_proc_frac_{time_boundary_layer}"
         o_time_proc_frac_self_col = f"o_{layer}_time_proc_frac_self"
-        o_time_proc_frac_total_col = o_time_col.replace(time_proc_metric, 'time_proc_frac_total')
+        o_time_proc_frac_total_col = o_time_proc_col.replace(time_proc_metric, 'time_proc_frac_total')
 
-        child_time_sum = sum(df[f"{child}_{time_proc_metric}"].fillna(0) for child in child_layers)
-        o_time = np.maximum(layer_time - child_time_sum, 0)
-        o_time_sum = o_time.sum()
+        child_time_proc_sum = sum(df[f"{child}_{time_proc_metric}"].fillna(0) for child in child_layers)
+        o_time_proc = np.maximum(layer_time_proc - child_time_proc_sum, 0)
+        o_time_proc_total = o_time_proc.sum()
 
-        o_time_series = pd.array(o_time, dtype='Float64')
-        x_layer_metrics[o_time_col] = o_time_series
-        x_layer_metrics[o_time_proc_frac_boundary_col] = o_time_series / df[time_proc_boundary_metric]
-        x_layer_metrics[o_time_proc_frac_self_col] = o_time_series / layer_time
+        o_time_proc_series = pd.array(o_time_proc, dtype='Float64')
+        x_layer_metrics[o_time_proc_col] = o_time_proc_series
+        x_layer_metrics[o_time_proc_frac_boundary_col] = o_time_proc_series / df[time_proc_boundary_metric]
+        x_layer_metrics[o_time_proc_frac_self_col] = o_time_proc_series / layer_time_proc
         x_layer_metrics[o_time_proc_frac_total_col] = pd.NA
-        if o_time_sum > 0:
-            x_layer_metrics[o_time_proc_frac_total_col] = o_time_series / o_time_sum
+        if o_time_proc_total > 0:
+            x_layer_metrics[o_time_proc_frac_total_col] = o_time_proc_series / o_time_proc_total
 
-        layer_has_time = layer_time.sum() > 0
+        # Call: overhead
+        o_time_call_col = f"o_{layer}_{time_call_metric}"
+        o_time_call_frac_boundary_col = f"o_{layer}_time_call_frac_{time_boundary_layer}"
+        o_time_call_frac_self_col = f"o_{layer}_time_call_frac_self"
+        o_time_call_frac_total_col = f"o_{layer}_time_call_frac_total"
+
+        child_time_call_sum = sum(df[f"{child}_{time_call_metric}"].fillna(0) for child in child_layers)
+        o_time_call = np.maximum(layer_time_call - child_time_call_sum, 0)
+        o_time_call_total = o_time_call.sum()
+
+        o_time_call_series = pd.array(o_time_call, dtype='Float64')
+        x_layer_metrics[o_time_call_col] = o_time_call_series
+        x_layer_metrics[o_time_call_frac_boundary_col] = o_time_call_series / df[time_call_boundary_metric]
+        x_layer_metrics[o_time_call_frac_self_col] = o_time_call_series / layer_time_call
+        x_layer_metrics[o_time_call_frac_total_col] = pd.NA
+        if o_time_call_total > 0:
+            x_layer_metrics[o_time_call_frac_total_col] = o_time_call_series / o_time_call_total
+
+        # Proc + Call: frac_parent
+        layer_has_time_proc = layer_time_proc.sum() > 0
+        layer_has_time_call = layer_time_call.sum() > 0
         for child_layer in child_layers:
             time_proc_frac_parent_col = f"{child_layer}_time_proc_frac_parent"
             x_layer_metrics[time_proc_frac_parent_col] = pd.NA
-            if layer_has_time:
-                x_layer_metrics[time_proc_frac_parent_col] = df[f"{child_layer}_{time_proc_metric}"] / layer_time
+            if layer_has_time_proc:
+                x_layer_metrics[time_proc_frac_parent_col] = df[f"{child_layer}_{time_proc_metric}"] / layer_time_proc
+
+            time_call_frac_parent_col = f"{child_layer}_time_call_frac_parent"
+            x_layer_metrics[time_call_frac_parent_col] = pd.NA
+            if layer_has_time_call:
+                x_layer_metrics[time_call_frac_parent_col] = df[f"{child_layer}_{time_call_metric}"] / layer_time_call
 
     # Set relational time metrics for derived metrics
     for layer in derived_metrics:
         for dm in derived_metrics[layer]:
             dm_col = f"{layer}_{dm}"
-            dm_time_col = f"{dm_col}_{time_proc_metric}"
+            dm_time_proc_col = f"{dm_col}_{time_proc_metric}"
+            dm_time_call_col = f"{dm_col}_{time_call_metric}"
 
-            if dm_time_col not in df.columns:
-                continue
+            # Proc
+            if dm_time_proc_col in df.columns:
+                dm_time_proc = df[dm_time_proc_col]
+                dm_time_proc_total = dm_time_proc.sum()
 
-            dm_time_proc_frac_boundary_col = f"{dm_col}_time_proc_frac_{time_boundary_layer}"
-            dm_time_proc_frac_parent_col = f"{dm_col}_time_proc_frac_parent"
-            dm_time_proc_frac_total_col = f"{dm_col}_time_proc_frac_total"
+                x_layer_metrics[f"{dm_col}_time_proc_frac_{time_boundary_layer}"] = dm_time_proc / df[time_proc_boundary_metric]
+                x_layer_metrics[f"{dm_col}_time_proc_frac_parent"] = dm_time_proc / df[f"{layer}_{time_proc_metric}"]
+                x_layer_metrics[f"{dm_col}_time_proc_frac_total"] = pd.NA
+                if dm_time_proc_total > 0:
+                    x_layer_metrics[f"{dm_col}_time_proc_frac_total"] = dm_time_proc / dm_time_proc_total
 
-            dm_time = df[dm_time_col]
-            dm_time_sum = dm_time.sum()
+            # Call
+            if dm_time_call_col in df.columns:
+                dm_time_call = df[dm_time_call_col]
+                dm_time_call_total = dm_time_call.sum()
 
-            x_layer_metrics[dm_time_proc_frac_boundary_col] = dm_time / df[time_proc_boundary_metric]
-            x_layer_metrics[dm_time_proc_frac_parent_col] = dm_time / df[f"{layer}_{time_proc_metric}"]
-            x_layer_metrics[dm_time_proc_frac_total_col] = pd.NA
-
-            if dm_time_sum > 0:
-                x_layer_metrics[dm_time_proc_frac_total_col] = dm_time / dm_time_sum
+                x_layer_metrics[f"{dm_col}_time_call_frac_{time_boundary_layer}"] = dm_time_call / df[time_call_boundary_metric]
+                x_layer_metrics[f"{dm_col}_time_call_frac_parent"] = dm_time_call / df[f"{layer}_{time_call_metric}"]
+                x_layer_metrics[f"{dm_col}_time_call_frac_total"] = pd.NA
+                if dm_time_call_total > 0:
+                    x_layer_metrics[f"{dm_col}_time_call_frac_total"] = dm_time_call / dm_time_call_total
 
     # Set unoverlapped times if there is compute time
     if compute_time_proc_metric in df.columns:
-        compute_time = df[compute_time_proc_metric].fillna(0).astype('Float64')
+        compute_time_proc = df[compute_time_proc_metric].fillna(0).astype('Float64')
+        compute_time_call = df[compute_time_call_metric].fillna(0).astype('Float64')
         # Set unoverlapped time metrics
         for async_layer in async_layers:
-            time_col = f"{async_layer}_{time_proc_metric}"
+            # Proc: unoverlapped
+            time_proc_col = f"{async_layer}_{time_proc_metric}"
+            u_time_proc_col = f"u_{time_proc_col}"
 
-            u_time_col = f"u_{time_col}"
-            u_time_proc_frac_boundary_col = f"u_{async_layer}_time_proc_frac_{time_boundary_layer}"
-            u_time_proc_frac_self_col = f"u_{async_layer}_time_proc_frac_self"
-            u_time_proc_frac_total_col = f"u_{async_layer}_time_proc_frac_total"
+            layer_time_proc = df[time_proc_col]
+            u_time_proc = (layer_time_proc - compute_time_proc).clip(lower=0).astype('Float64')
+            u_time_proc_total = u_time_proc.sum()
 
-            layer_time = df[time_col]
-            u_time = (layer_time - compute_time).clip(lower=0).astype('Float64')
-            u_time_sum = u_time.sum()
-
-            u_time_series = pd.array(u_time, dtype='Float64')
-            x_layer_metrics[u_time_col] = u_time_series
-            x_layer_metrics[u_time_proc_frac_self_col] = u_time_series / layer_time
-            x_layer_metrics[u_time_proc_frac_boundary_col] = u_time_series / df[time_proc_boundary_metric]
-            x_layer_metrics[u_time_proc_frac_total_col] = pd.NA
-            if u_time_sum > 0:
-                x_layer_metrics[u_time_proc_frac_total_col] = u_time_series / u_time_sum
+            u_time_proc_series = pd.array(u_time_proc, dtype='Float64')
+            x_layer_metrics[u_time_proc_col] = u_time_proc_series
+            x_layer_metrics[f"u_{async_layer}_time_proc_frac_self"] = u_time_proc_series / layer_time_proc
+            x_layer_metrics[f"u_{async_layer}_time_proc_frac_{time_boundary_layer}"] = u_time_proc_series / df[time_proc_boundary_metric]
+            x_layer_metrics[f"u_{async_layer}_time_proc_frac_total"] = pd.NA
+            if u_time_proc_total > 0:
+                x_layer_metrics[f"u_{async_layer}_time_proc_frac_total"] = u_time_proc_series / u_time_proc_total
 
             parent_layer = layer_deps.get(async_layer)
             if parent_layer:
-                u_time_proc_frac_parent_col = f"u_{async_layer}_time_proc_frac_parent"
-                x_layer_metrics[u_time_proc_frac_parent_col] = u_time_series / df[f"{parent_layer}_{time_proc_metric}"]
+                x_layer_metrics[f"u_{async_layer}_time_proc_frac_parent"] = u_time_proc_series / df[f"{parent_layer}_{time_proc_metric}"]
+
+            # Call: unoverlapped
+            time_call_col = f"{async_layer}_{time_call_metric}"
+            u_time_call_col = f"u_{time_call_col}"
+
+            layer_time_call = df[time_call_col]
+            u_time_call = (layer_time_call - compute_time_call).clip(lower=0).astype('Float64')
+            u_time_call_total = u_time_call.sum()
+
+            u_time_call_series = pd.array(u_time_call, dtype='Float64')
+            x_layer_metrics[u_time_call_col] = u_time_call_series
+            x_layer_metrics[f"u_{async_layer}_time_call_frac_self"] = u_time_call_series / layer_time_call
+            x_layer_metrics[f"u_{async_layer}_time_call_frac_{time_boundary_layer}"] = u_time_call_series / df[time_call_boundary_metric]
+            x_layer_metrics[f"u_{async_layer}_time_call_frac_total"] = pd.NA
+            if u_time_call_total > 0:
+                x_layer_metrics[f"u_{async_layer}_time_call_frac_total"] = u_time_call_series / u_time_call_total
+
+            if parent_layer:
+                x_layer_metrics[f"u_{async_layer}_time_call_frac_parent"] = u_time_call_series / df[f"{parent_layer}_{time_call_metric}"]
 
     if x_layer_metrics:
         x_layer_metrics_df = pd.DataFrame(x_layer_metrics, index=df.index)

--- a/python/dftracer/analyzer/output.py
+++ b/python/dftracer/analyzer/output.py
@@ -89,7 +89,7 @@ class Output(abc.ABC):
             unique_process_count=int(raw_stats.unique_process_count),
         )
         is_process_based = view_key[-1] == COL_PROC_NAME
-        time_metric = 'time_sum' if is_process_based else 'time_max'
+        time_metric = 'time_sum' if is_process_based else 'time_proc_max'
         for layer in result.layers:
             times = flat_view.get(f"{layer}_{time_metric}", pd.Series([0.0]))
             time = times.max() if is_process_based else times.sum()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -136,11 +136,17 @@ def test_set_view_metrics_process_based_basic():
     # frac_total values
     assert pytest.approx(out.loc[0, "count_frac_total"], rel=1e-6) == 6.0 / 8.0
     assert pytest.approx(out.loc[1, "count_frac_total"], rel=1e-6) == 2.0 / 8.0
-    assert pytest.approx(out.loc[0, "size_frac_total"], rel=1e-6) == 300.0 / 400.0
-    assert pytest.approx(out.loc[1, "size_frac_total"], rel=1e-6) == 100.0 / 400.0
-    assert pytest.approx(out.loc[0, "time_frac_total"], rel=1e-6) == 3.0 / 4.0
-    assert pytest.approx(out.loc[1, "time_frac_total"], rel=1e-6) == 1.0 / 4.0
-    # ops slope = time_frac_total / count_frac_total
+    assert pytest.approx(out.loc[0, "size_proc_frac_total"], rel=1e-6) == 300.0 / 400.0
+    assert pytest.approx(out.loc[1, "size_proc_frac_total"], rel=1e-6) == 100.0 / 400.0
+    # size_call_frac_total (same as proc when process-based, both from size_sum)
+    assert pytest.approx(out.loc[0, "size_call_frac_total"], rel=1e-6) == 300.0 / 400.0
+    assert pytest.approx(out.loc[1, "size_call_frac_total"], rel=1e-6) == 100.0 / 400.0
+    assert pytest.approx(out.loc[0, "time_proc_frac_total"], rel=1e-6) == 3.0 / 4.0
+    assert pytest.approx(out.loc[1, "time_proc_frac_total"], rel=1e-6) == 1.0 / 4.0
+    # time_call_frac_total (same as proc when process-based, both from time_sum)
+    assert pytest.approx(out.loc[0, "time_call_frac_total"], rel=1e-6) == 3.0 / 4.0
+    assert pytest.approx(out.loc[1, "time_call_frac_total"], rel=1e-6) == 1.0 / 4.0
+    # ops slope = time_proc_frac_total / count_frac_total
     assert pytest.approx(out.loc[0, "ops_slope"], rel=1e-6) == 1.0
     assert pytest.approx(out.loc[1, "ops_slope"], rel=1e-6) == 1.0
     # ops percentile ranks; equal slopes -> equal percentile
@@ -151,25 +157,34 @@ def test_set_view_metrics_process_based_basic():
 
 
 def test_set_view_metrics_non_process_based_basic():
-    # Uses time_max when not process-based
+    # Uses time_proc_max / size_proc_max when not process-based
     df = pd.DataFrame(
         {
             "count_sum": [6.0, 2.0],
             "size_sum": [300.0, 100.0],
-            "time_max": [3.0, 1.0],
+            "size_proc_max": [200.0, 80.0],
+            "time_sum": [5.0, 3.0],
+            "time_proc_max": [3.0, 1.0],
         }
     )
-    metric_boundaries = {"time_max": 10.0}
+    metric_boundaries = {"time_proc_max": 10.0}
 
     out = set_view_metrics(df.copy(), metric_boundaries=metric_boundaries, is_view_process_based=False)
 
-    assert pytest.approx(out.loc[0, "time_frac_total"], rel=1e-6) == 3.0 / 4.0
-    assert pytest.approx(out.loc[1, "time_frac_total"], rel=1e-6) == 1.0 / 4.0
-    # count/size fractions based on sums
+    assert pytest.approx(out.loc[0, "time_proc_frac_total"], rel=1e-6) == 3.0 / 4.0
+    assert pytest.approx(out.loc[1, "time_proc_frac_total"], rel=1e-6) == 1.0 / 4.0
+    # time_call_frac_total (from time_sum, not time_proc_max)
+    assert pytest.approx(out.loc[0, "time_call_frac_total"], rel=1e-6) == 5.0 / 8.0
+    assert pytest.approx(out.loc[1, "time_call_frac_total"], rel=1e-6) == 3.0 / 8.0
+    # count fractions based on sums
     assert pytest.approx(out.loc[0, "count_frac_total"], rel=1e-6) == 6.0 / 8.0
     assert pytest.approx(out.loc[1, "count_frac_total"], rel=1e-6) == 2.0 / 8.0
-    assert pytest.approx(out.loc[0, "size_frac_total"], rel=1e-6) == 300.0 / 400.0
-    assert pytest.approx(out.loc[1, "size_frac_total"], rel=1e-6) == 100.0 / 400.0
+    # size_proc_frac_total (from size_proc_max, not size_sum)
+    assert pytest.approx(out.loc[0, "size_proc_frac_total"], rel=1e-6) == 200.0 / 280.0
+    assert pytest.approx(out.loc[1, "size_proc_frac_total"], rel=1e-6) == 80.0 / 280.0
+    # size_call_frac_total (from size_sum)
+    assert pytest.approx(out.loc[0, "size_call_frac_total"], rel=1e-6) == 300.0 / 400.0
+    assert pytest.approx(out.loc[1, "size_call_frac_total"], rel=1e-6) == 100.0 / 400.0
     # ops slope defined and finite
     assert pytest.approx(out.loc[0, "ops_slope"], rel=1e-6) == (3 / 4) / (6 / 8)
     assert pytest.approx(out.loc[1, "ops_slope"], rel=1e-6) == (1 / 4) / (2 / 8)
@@ -213,10 +228,16 @@ def test_set_view_metrics_multiple_prefixes():
 
     # read_* fractions
     assert pytest.approx(out.loc[0, "read_count_frac_total"], rel=1e-6) == 4.0 / 10.0
-    assert pytest.approx(out.loc[0, "read_time_frac_total"], rel=1e-6) == 1.0 / 4.0
+    assert pytest.approx(out.loc[0, "read_time_proc_frac_total"], rel=1e-6) == 1.0 / 4.0
     # write_* fractions
     assert pytest.approx(out.loc[1, "write_count_frac_total"], rel=1e-6) == 8.0 / 10.0
-    assert pytest.approx(out.loc[1, "write_time_frac_total"], rel=1e-6) == 2.0 / 4.0
+    assert pytest.approx(out.loc[1, "write_time_proc_frac_total"], rel=1e-6) == 2.0 / 4.0
+    # size_call_frac_total (same as proc when process-based)
+    assert pytest.approx(out.loc[0, "read_size_call_frac_total"], rel=1e-6) == 40.0 / 100.0
+    assert pytest.approx(out.loc[1, "write_size_call_frac_total"], rel=1e-6) == 80.0 / 100.0
+    # time_call_frac_total (same as proc when process-based)
+    assert pytest.approx(out.loc[0, "read_time_call_frac_total"], rel=1e-6) == 1.0 / 4.0
+    assert pytest.approx(out.loc[1, "write_time_call_frac_total"], rel=1e-6) == 2.0 / 4.0
     # ops_slope & ops_percentile exist per family
     assert "read_ops_slope" in out.columns and "write_ops_slope" in out.columns
     assert "read_ops_percentile" in out.columns and "write_ops_percentile" in out.columns
@@ -224,7 +245,7 @@ def test_set_view_metrics_multiple_prefixes():
 
 
 def test_set_view_metrics_zero_size_sum_denominator_safe():
-    # Sum of size_sum is zero -> size_frac_total should be NA, not raise
+    # Sum of size_sum is zero -> size_proc_frac_total and size_call_frac_total should be NA
     df = pd.DataFrame(
         {
             "count_sum": [1.0, 2.0],
@@ -234,7 +255,8 @@ def test_set_view_metrics_zero_size_sum_denominator_safe():
     )
     metric_boundaries = {"time_sum": 10.0}
     out = set_view_metrics(df.copy(), metric_boundaries=metric_boundaries, is_view_process_based=True)
-    assert pd.isna(out.loc[0, "size_frac_total"]) and pd.isna(out.loc[1, "size_frac_total"])
+    assert pd.isna(out.loc[0, "size_proc_frac_total"]) and pd.isna(out.loc[1, "size_proc_frac_total"])
+    assert pd.isna(out.loc[0, "size_call_frac_total"]) and pd.isna(out.loc[1, "size_call_frac_total"])
     _assert_no_infinities(out)
 
 
@@ -256,7 +278,7 @@ def test_set_view_metrics_zero_count_sum_denominator_safe():
 
 
 def test_set_view_metrics_zero_time_denominator_safe_process_and_non():
-    # All time metrics zero -> time_frac_total should be NA
+    # All time metrics zero -> time_proc_frac_total should be NA
     df_proc = pd.DataFrame(
         {
             "count_sum": [1.0, 1.0],
@@ -265,17 +287,23 @@ def test_set_view_metrics_zero_time_denominator_safe_process_and_non():
         }
     )
     out_proc = set_view_metrics(df_proc.copy(), metric_boundaries={}, is_view_process_based=True)
-    assert pd.isna(out_proc.loc[0, "time_frac_total"]) and pd.isna(out_proc.loc[1, "time_frac_total"])
+    assert pd.isna(out_proc.loc[0, "time_proc_frac_total"]) and pd.isna(out_proc.loc[1, "time_proc_frac_total"])
+    assert pd.isna(out_proc.loc[0, "time_call_frac_total"]) and pd.isna(out_proc.loc[1, "time_call_frac_total"])
 
     df_non = pd.DataFrame(
         {
             "count_sum": [1.0, 1.0],
-            "size_sum": [10.0, 20.0],
-            "time_max": [0.0, 0.0],
+            "size_sum": [0.0, 0.0],
+            "size_proc_max": [0.0, 0.0],
+            "time_sum": [0.0, 0.0],
+            "time_proc_max": [0.0, 0.0],
         }
     )
     out_non = set_view_metrics(df_non.copy(), metric_boundaries={}, is_view_process_based=False)
-    assert pd.isna(out_non.loc[0, "time_frac_total"]) and pd.isna(out_non.loc[1, "time_frac_total"])
+    assert pd.isna(out_non.loc[0, "time_proc_frac_total"]) and pd.isna(out_non.loc[1, "time_proc_frac_total"])
+    assert pd.isna(out_non.loc[0, "time_call_frac_total"]) and pd.isna(out_non.loc[1, "time_call_frac_total"])
+    assert pd.isna(out_non.loc[0, "size_proc_frac_total"]) and pd.isna(out_non.loc[1, "size_proc_frac_total"])
+    assert pd.isna(out_non.loc[0, "size_call_frac_total"]) and pd.isna(out_non.loc[1, "size_call_frac_total"])
     _assert_no_infinities(out_proc)
     _assert_no_infinities(out_non)
 
@@ -305,36 +333,36 @@ def test_set_cross_layer_metrics_process_based_basic():
     )
 
     # Root boundary fractions present and correct (A_time / A_time)
-    assert pytest.approx(out.loc[0, "A_time_frac_A"], rel=1e-6) == 1.0
-    assert pytest.approx(out.loc[1, "A_time_frac_A"], rel=1e-6) == 1.0
-    assert pd.isna(out.loc[2, "A_time_frac_A"])  # 0/0 -> NA
+    assert pytest.approx(out.loc[0, "A_time_proc_frac_A"], rel=1e-6) == 1.0
+    assert pytest.approx(out.loc[1, "A_time_proc_frac_A"], rel=1e-6) == 1.0
+    assert pd.isna(out.loc[2, "A_time_proc_frac_A"])  # 0/0 -> NA
 
     # Child boundary fractions: layer_time / A_time
-    assert pytest.approx(out.loc[0, "B_time_frac_A"], rel=1e-6) == 3.0 / 10.0
-    assert pytest.approx(out.loc[1, "B_time_frac_A"], rel=1e-6) == 8.0 / 8.0
-    assert pytest.approx(out.loc[0, "C_time_frac_A"], rel=1e-6) == 2.0 / 10.0
+    assert pytest.approx(out.loc[0, "B_time_proc_frac_A"], rel=1e-6) == 3.0 / 10.0
+    assert pytest.approx(out.loc[1, "B_time_proc_frac_A"], rel=1e-6) == 8.0 / 8.0
+    assert pytest.approx(out.loc[0, "C_time_proc_frac_A"], rel=1e-6) == 2.0 / 10.0
 
     # Overhead for A: max(A - B - C, 0)
     assert pytest.approx(out.loc[0, "o_A_time_sum"], rel=1e-6) == 5.0
     assert pytest.approx(out.loc[1, "o_A_time_sum"], rel=1e-6) == 0.0
-    assert pytest.approx(out.loc[0, "o_A_time_frac_self"], rel=1e-6) == 5.0 / 10.0
-    assert pytest.approx(out.loc[0, "o_A_time_frac_A"], rel=1e-6) == 5.0 / 10.0
+    assert pytest.approx(out.loc[0, "o_A_time_proc_frac_self"], rel=1e-6) == 5.0 / 10.0
+    assert pytest.approx(out.loc[0, "o_A_time_proc_frac_A"], rel=1e-6) == 5.0 / 10.0
     # Total overhead fraction across rows: 5 / (5 + 0 + 0)
-    assert pytest.approx(out.loc[0, "o_A_time_frac_total"], rel=1e-6) == 1.0
-    assert pytest.approx(out.loc[1, "o_A_time_frac_total"], rel=1e-6) == 0.0
+    assert pytest.approx(out.loc[0, "o_A_time_proc_frac_total"], rel=1e-6) == 1.0
+    assert pytest.approx(out.loc[1, "o_A_time_proc_frac_total"], rel=1e-6) == 0.0
 
     # Child to parent fractions
-    assert pytest.approx(out.loc[0, "B_time_frac_parent"], rel=1e-6) == 3.0 / 10.0
-    assert pytest.approx(out.loc[1, "B_time_frac_parent"], rel=1e-6) == 8.0 / 8.0
+    assert pytest.approx(out.loc[0, "B_time_proc_frac_parent"], rel=1e-6) == 3.0 / 10.0
+    assert pytest.approx(out.loc[1, "B_time_proc_frac_parent"], rel=1e-6) == 8.0 / 8.0
 
     # Unoverlapped for async layer B: max(B - compute, 0)
     assert pytest.approx(out.loc[0, "u_B_time_sum"], rel=1e-6) == 0.0
     assert pytest.approx(out.loc[1, "u_B_time_sum"], rel=1e-6) == 7.0
     # Fractions
-    assert pytest.approx(out.loc[1, "u_B_time_frac_self"], rel=1e-6) == 7.0 / 8.0
-    assert pytest.approx(out.loc[1, "u_B_time_frac_A"], rel=1e-6) == 7.0 / 8.0
-    assert pytest.approx(out.loc[1, "u_B_time_frac_total"], rel=1e-6) == 1.0
-    assert pytest.approx(out.loc[1, "u_B_time_frac_parent"], rel=1e-6) == 7.0 / 8.0
+    assert pytest.approx(out.loc[1, "u_B_time_proc_frac_self"], rel=1e-6) == 7.0 / 8.0
+    assert pytest.approx(out.loc[1, "u_B_time_proc_frac_A"], rel=1e-6) == 7.0 / 8.0
+    assert pytest.approx(out.loc[1, "u_B_time_proc_frac_total"], rel=1e-6) == 1.0
+    assert pytest.approx(out.loc[1, "u_B_time_proc_frac_parent"], rel=1e-6) == 7.0 / 8.0
 
     # NA cleanup (no infinities)
     _assert_no_infinities(out)
@@ -345,9 +373,9 @@ def test_set_cross_layer_metrics_non_process_based_basic():
     async_layers = ["B"]
     df = pd.DataFrame(
         {
-            "A_time_max": [5.0, 0.0],
-            "B_time_max": [2.0, 0.0],
-            "compute_time_max": [1.0, 0.0],
+            "A_time_proc_max": [5.0, 0.0],
+            "B_time_proc_max": [2.0, 0.0],
+            "compute_time_proc_max": [1.0, 0.0],
         }
     )
 
@@ -362,13 +390,13 @@ def test_set_cross_layer_metrics_non_process_based_basic():
     )
 
     # Root boundary fraction present
-    assert pytest.approx(out.loc[0, "A_time_frac_A"], rel=1e-6) == 1.0
-    assert pd.isna(out.loc[1, "A_time_frac_A"])  # 0/0 -> NA
+    assert pytest.approx(out.loc[0, "A_time_proc_frac_A"], rel=1e-6) == 1.0
+    assert pd.isna(out.loc[1, "A_time_proc_frac_A"])  # 0/0 -> NA
 
-    # Unoverlapped for B with time_max
-    assert pytest.approx(out.loc[0, "u_B_time_max"], rel=1e-6) == 1.0
-    assert pytest.approx(out.loc[0, "u_B_time_frac_self"], rel=1e-6) == 1.0 / 2.0
-    assert pytest.approx(out.loc[0, "u_B_time_frac_A"], rel=1e-6) == 1.0 / 5.0
+    # Unoverlapped for B with time_proc_max
+    assert pytest.approx(out.loc[0, "u_B_time_proc_max"], rel=1e-6) == 1.0
+    assert pytest.approx(out.loc[0, "u_B_time_proc_frac_self"], rel=1e-6) == 1.0 / 2.0
+    assert pytest.approx(out.loc[0, "u_B_time_proc_frac_A"], rel=1e-6) == 1.0 / 5.0
     _assert_no_infinities(out)
 
 
@@ -395,12 +423,12 @@ def test_set_cross_layer_metrics_zero_denominators_produce_na():
     )
 
     # Divisions by zero -> NA
-    assert pd.isna(out.loc[0, "A_time_frac_A"])  # 0/0
-    assert pd.isna(out.loc[0, "B_time_frac_A"])  # 1/0 -> NA after cleanup
-    assert pd.isna(out.loc[0, "B_time_frac_parent"])  # 1/0
+    assert pd.isna(out.loc[0, "A_time_proc_frac_A"])  # 0/0
+    assert pd.isna(out.loc[0, "B_time_proc_frac_A"])  # 1/0 -> NA after cleanup
+    assert pd.isna(out.loc[0, "B_time_proc_frac_parent"])  # 1/0
     # Unoverlapped 0 vs compute
     assert pytest.approx(out.loc[0, "u_B_time_sum"], rel=1e-6) == 0.0
-    assert pd.isna(out.loc[0, "u_B_time_frac_A"])  # 0/0
+    assert pd.isna(out.loc[0, "u_B_time_proc_frac_A"])  # 0/0
     _assert_no_infinities(out)
 
 
@@ -429,12 +457,12 @@ def test_set_cross_layer_metrics_with_derived_metrics():
     )
 
     # Derived metric fractions
-    assert pytest.approx(out.loc[0, "A_foo_time_frac_A"], rel=1e-6) == 4.0 / 10.0
-    assert pytest.approx(out.loc[1, "A_foo_time_frac_A"], rel=1e-6) == 6.0 / 10.0
-    assert pytest.approx(out.loc[0, "A_foo_time_frac_parent"], rel=1e-6) == 4.0 / 10.0
-    assert pytest.approx(out.loc[1, "A_foo_time_frac_parent"], rel=1e-6) == 6.0 / 10.0
-    assert pytest.approx(out.loc[0, "A_foo_time_frac_total"], rel=1e-6) == 0.4
-    assert pytest.approx(out.loc[1, "A_foo_time_frac_total"], rel=1e-6) == 0.6
+    assert pytest.approx(out.loc[0, "A_foo_time_proc_frac_A"], rel=1e-6) == 4.0 / 10.0
+    assert pytest.approx(out.loc[1, "A_foo_time_proc_frac_A"], rel=1e-6) == 6.0 / 10.0
+    assert pytest.approx(out.loc[0, "A_foo_time_proc_frac_parent"], rel=1e-6) == 4.0 / 10.0
+    assert pytest.approx(out.loc[1, "A_foo_time_proc_frac_parent"], rel=1e-6) == 6.0 / 10.0
+    assert pytest.approx(out.loc[0, "A_foo_time_proc_frac_total"], rel=1e-6) == 0.4
+    assert pytest.approx(out.loc[1, "A_foo_time_proc_frac_total"], rel=1e-6) == 0.6
     _assert_no_infinities(out)
 
 
@@ -461,10 +489,10 @@ def test_set_cross_layer_metrics_derived_metrics_zero_denoms():
         time_boundary_layer="A",
     )
 
-    assert pd.isna(out.loc[0, "A_foo_time_frac_A"])  # 0/0
-    assert pd.isna(out.loc[0, "A_foo_time_frac_parent"])  # 0/0
+    assert pd.isna(out.loc[0, "A_foo_time_proc_frac_A"])  # 0/0
+    assert pd.isna(out.loc[0, "A_foo_time_proc_frac_parent"])  # 0/0
     # total fraction is 0/0 as well -> NA for both rows
-    assert pd.isna(out.loc[0, "A_foo_time_frac_total"]) and pd.isna(out.loc[1, "A_foo_time_frac_total"])
+    assert pd.isna(out.loc[0, "A_foo_time_proc_frac_total"]) and pd.isna(out.loc[1, "A_foo_time_proc_frac_total"])
     _assert_no_infinities(out)
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -364,6 +364,16 @@ def test_set_cross_layer_metrics_process_based_basic():
     assert pytest.approx(out.loc[1, "u_B_time_proc_frac_total"], rel=1e-6) == 1.0
     assert pytest.approx(out.loc[1, "u_B_time_proc_frac_parent"], rel=1e-6) == 7.0 / 8.0
 
+    # Call variants: for process-based views, call == proc (both use time_sum)
+    assert pytest.approx(out.loc[0, "A_time_call_frac_A"], rel=1e-6) == 1.0
+    assert pytest.approx(out.loc[0, "B_time_call_frac_A"], rel=1e-6) == 3.0 / 10.0
+    assert pytest.approx(out.loc[0, "o_A_time_call_frac_self"], rel=1e-6) == 5.0 / 10.0
+    assert pytest.approx(out.loc[0, "o_A_time_call_frac_A"], rel=1e-6) == 5.0 / 10.0
+    assert pytest.approx(out.loc[0, "o_A_time_call_frac_total"], rel=1e-6) == 1.0
+    assert pytest.approx(out.loc[0, "B_time_call_frac_parent"], rel=1e-6) == 3.0 / 10.0
+    assert pytest.approx(out.loc[1, "u_B_time_call_frac_self"], rel=1e-6) == 7.0 / 8.0
+    assert pytest.approx(out.loc[1, "u_B_time_call_frac_parent"], rel=1e-6) == 7.0 / 8.0
+
     # NA cleanup (no infinities)
     _assert_no_infinities(out)
 
@@ -376,6 +386,10 @@ def test_set_cross_layer_metrics_non_process_based_basic():
             "A_time_proc_max": [5.0, 0.0],
             "B_time_proc_max": [2.0, 0.0],
             "compute_time_proc_max": [1.0, 0.0],
+            # Call track always uses time_sum (aggregate across processes)
+            "A_time_sum": [12.0, 0.0],
+            "B_time_sum": [7.0, 0.0],
+            "compute_time_sum": [3.0, 0.0],
         }
     )
 
@@ -389,14 +403,45 @@ def test_set_cross_layer_metrics_non_process_based_basic():
         time_boundary_layer="A",
     )
 
-    # Root boundary fraction present
+    # Proc: root boundary fraction
     assert pytest.approx(out.loc[0, "A_time_proc_frac_A"], rel=1e-6) == 1.0
     assert pd.isna(out.loc[1, "A_time_proc_frac_A"])  # 0/0 -> NA
 
-    # Unoverlapped for B with time_proc_max
+    # Proc: unoverlapped for B with time_proc_max
     assert pytest.approx(out.loc[0, "u_B_time_proc_max"], rel=1e-6) == 1.0
     assert pytest.approx(out.loc[0, "u_B_time_proc_frac_self"], rel=1e-6) == 1.0 / 2.0
     assert pytest.approx(out.loc[0, "u_B_time_proc_frac_A"], rel=1e-6) == 1.0 / 5.0
+
+    # Proc: overhead for A: max(5 - 2, 0) = 3
+    assert pytest.approx(out.loc[0, "o_A_time_proc_max"], rel=1e-6) == 3.0
+    assert pytest.approx(out.loc[0, "o_A_time_proc_frac_A"], rel=1e-6) == 3.0 / 5.0
+
+    # Proc: child to parent: B/A = 2/5
+    assert pytest.approx(out.loc[0, "B_time_proc_frac_parent"], rel=1e-6) == 2.0 / 5.0
+
+    # Call: boundary fractions (uses time_sum)
+    assert pytest.approx(out.loc[0, "A_time_call_frac_A"], rel=1e-6) == 1.0
+    assert pd.isna(out.loc[1, "A_time_call_frac_A"])  # 0/0 -> NA
+    assert pytest.approx(out.loc[0, "B_time_call_frac_A"], rel=1e-6) == 7.0 / 12.0
+
+    # Call: overhead for A: max(12 - 7, 0) = 5
+    assert pytest.approx(out.loc[0, "o_A_time_sum"], rel=1e-6) == 5.0
+    assert pytest.approx(out.loc[0, "o_A_time_call_frac_A"], rel=1e-6) == 5.0 / 12.0
+    assert pytest.approx(out.loc[0, "o_A_time_call_frac_self"], rel=1e-6) == 5.0 / 12.0
+
+    # Call: child to parent: B/A = 7/12
+    assert pytest.approx(out.loc[0, "B_time_call_frac_parent"], rel=1e-6) == 7.0 / 12.0
+
+    # Call: unoverlapped for B: max(7 - 3, 0) = 4
+    assert pytest.approx(out.loc[0, "u_B_time_sum"], rel=1e-6) == 4.0
+    assert pytest.approx(out.loc[0, "u_B_time_call_frac_self"], rel=1e-6) == 4.0 / 7.0
+    assert pytest.approx(out.loc[0, "u_B_time_call_frac_A"], rel=1e-6) == 4.0 / 12.0
+    assert pytest.approx(out.loc[0, "u_B_time_call_frac_parent"], rel=1e-6) == 4.0 / 12.0
+
+    # Verify proc and call differ (non-process-based view)
+    assert out.loc[0, "B_time_proc_frac_A"] != out.loc[0, "B_time_call_frac_A"]
+    assert out.loc[0, "o_A_time_proc_frac_A"] != out.loc[0, "o_A_time_call_frac_A"]
+
     _assert_no_infinities(out)
 
 
@@ -429,6 +474,12 @@ def test_set_cross_layer_metrics_zero_denominators_produce_na():
     # Unoverlapped 0 vs compute
     assert pytest.approx(out.loc[0, "u_B_time_sum"], rel=1e-6) == 0.0
     assert pd.isna(out.loc[0, "u_B_time_proc_frac_A"])  # 0/0
+
+    # Call variants: same zero-denominator behavior
+    assert pd.isna(out.loc[0, "A_time_call_frac_A"])  # 0/0
+    assert pd.isna(out.loc[0, "B_time_call_frac_A"])  # 1/0 -> NA
+    assert pd.isna(out.loc[0, "B_time_call_frac_parent"])  # 1/0
+    assert pd.isna(out.loc[0, "u_B_time_call_frac_A"])  # 0/0
     _assert_no_infinities(out)
 
 
@@ -456,13 +507,19 @@ def test_set_cross_layer_metrics_with_derived_metrics():
         time_boundary_layer="A",
     )
 
-    # Derived metric fractions
+    # Derived metric fractions (proc)
     assert pytest.approx(out.loc[0, "A_foo_time_proc_frac_A"], rel=1e-6) == 4.0 / 10.0
     assert pytest.approx(out.loc[1, "A_foo_time_proc_frac_A"], rel=1e-6) == 6.0 / 10.0
     assert pytest.approx(out.loc[0, "A_foo_time_proc_frac_parent"], rel=1e-6) == 4.0 / 10.0
     assert pytest.approx(out.loc[1, "A_foo_time_proc_frac_parent"], rel=1e-6) == 6.0 / 10.0
     assert pytest.approx(out.loc[0, "A_foo_time_proc_frac_total"], rel=1e-6) == 0.4
     assert pytest.approx(out.loc[1, "A_foo_time_proc_frac_total"], rel=1e-6) == 0.6
+
+    # Derived metric fractions (call): same as proc for process-based views
+    assert pytest.approx(out.loc[0, "A_foo_time_call_frac_A"], rel=1e-6) == 4.0 / 10.0
+    assert pytest.approx(out.loc[1, "A_foo_time_call_frac_A"], rel=1e-6) == 6.0 / 10.0
+    assert pytest.approx(out.loc[0, "A_foo_time_call_frac_parent"], rel=1e-6) == 4.0 / 10.0
+    assert pytest.approx(out.loc[0, "A_foo_time_call_frac_total"], rel=1e-6) == 0.4
     _assert_no_infinities(out)
 
 
@@ -493,6 +550,11 @@ def test_set_cross_layer_metrics_derived_metrics_zero_denoms():
     assert pd.isna(out.loc[0, "A_foo_time_proc_frac_parent"])  # 0/0
     # total fraction is 0/0 as well -> NA for both rows
     assert pd.isna(out.loc[0, "A_foo_time_proc_frac_total"]) and pd.isna(out.loc[1, "A_foo_time_proc_frac_total"])
+
+    # Call variants: same zero-denominator behavior
+    assert pd.isna(out.loc[0, "A_foo_time_call_frac_A"])  # 0/0
+    assert pd.isna(out.loc[0, "A_foo_time_call_frac_parent"])  # 0/0
+    assert pd.isna(out.loc[0, "A_foo_time_call_frac_total"]) and pd.isna(out.loc[1, "A_foo_time_call_frac_total"])
     _assert_no_infinities(out)
 
 


### PR DESCRIPTION
This pull request introduces enhancements to the statistics and metrics computation pipeline, focusing on clearer separation between per-process and per-call metrics, and improving the calculation and naming of derived statistics. The main changes include new utility functions for column renaming and per-call statistics derivation, updates to aggregation logic, and expanded metric calculations for both process-level and call-level views.

**Statistics and column handling improvements:**

* Added `build_view_rename_map` to standardize column names for view-level statistics, ensuring per-process and per-call metrics are clearly distinguished and fixing naming inconsistencies.
* Introduced `derive_call_stats`, which computes per-call mean and standard deviation from sum-of-squares columns and cleans up intermediary columns.
* Updated aggregation logic in `_compute_view` and related functions to handle new per-call and per-process metric suffixes, ensuring correct aggregation functions are applied for each metric type. [[1]](diffhunk://#diff-444fe7b2c8a8f206c6c5f1ffcc69a1cbb5e4afa07a156946134fa0f9f9471203R1059-R1063) [[2]](diffhunk://#diff-444fe7b2c8a8f206c6c5f1ffcc69a1cbb5e4afa07a156946134fa0f9f9471203R1099-R1104) [[3]](diffhunk://#diff-444fe7b2c8a8f206c6c5f1ffcc69a1cbb5e4afa07a156946134fa0f9f9471203L1104-R1152)

**Metric calculation enhancements:**

* Refactored metric suffixes and calculations in `set_view_metrics` to separately compute process-level (`*_proc_*`) and call-level (`*_call_*`) metrics, including new fractional metrics for both categories. [[1]](diffhunk://#diff-64f88101ddf458f49431cf22d2fdfb062007f2aa32c7b9d1b37e336e8a2dd6ebL89-R92) [[2]](diffhunk://#diff-64f88101ddf458f49431cf22d2fdfb062007f2aa32c7b9d1b37e336e8a2dd6ebL104-R146)
* Expanded the calculation of fractional and percentile metrics to cover both process-based and call-based statistics, improving the granularity of performance analysis.

**Consistency and naming updates:**

* Updated references and logic throughout the analyzer to use the new process-level metric suffixes (`*_proc_*`), replacing previous ambiguous suffixes and ensuring consistent metric naming in all views and additional metric calculations. [[1]](diffhunk://#diff-444fe7b2c8a8f206c6c5f1ffcc69a1cbb5e4afa07a156946134fa0f9f9471203L950-R957) [[2]](diffhunk://#diff-444fe7b2c8a8f206c6c5f1ffcc69a1cbb5e4afa07a156946134fa0f9f9471203L1156-R1203)

These changes collectively improve the clarity, accuracy, and flexibility of metric computation in the analysis pipeline.