### PR TITLE
Fix CI builds with Arrow 24 and restored Meson compatibility

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade auditwheel build "meson>=1.5.0,<1.10.0" meson-python patchelf setuptools wheel
+          pip install --upgrade auditwheel build "meson>=1.5.0,!=1.10.0" meson-python patchelf setuptools wheel
       - name: Build DFAnalyzer
         run: |
           python3 -m build -Csetup-args="--prefix=$HOME/.local" -Csetup-args="-Denable_tools=true" .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade "meson>=1.5.0,<1.10.0" meson-python setuptools wheel
+          pip install --upgrade "meson>=1.5.0,!=1.10.0" meson-python setuptools wheel
           pip install -r tests/requirements.txt
 
       - name: Install DFAnalyzer

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /dfanalyzer
 COPY . .
 
 RUN pip install --upgrade pip && \
-    pip install build "meson>=1.5.0,<1.10.0" meson-python setuptools streamlit wheel && \
+    pip install build "meson>=1.5.0,!=1.10.0" meson-python setuptools streamlit wheel && \
     pip install .[darshan] -Csetup-args="-Denable_tools=true"
 
 ENTRYPOINT ["dfanalyzer"]

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
     ['c', 'cpp'],
     meson_version: '>= 1.5.0',
     version: run_command(['scripts/versioning/scm_version.py', 'version'], check: true).stdout().strip(),
-    default_options: ['buildtype=debugoptimized', 'cpp_std=c++17', 'warning_level=3'],
+    default_options: ['buildtype=debugoptimized', 'cpp_std=c++20', 'warning_level=3'],
 )
 
 #### VERSIONING FILE ####

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "mesonpy"
-requires = ["meson>=1.5.0,<1.10.0", "meson-python>=0.15.0"]
+requires = ["meson>=1.5.0,!=1.10.0", "meson-python>=0.15.0"]
 
 [project]
 name = "dftracer-analyzer"

--- a/tools/recorder2parquet.cpp
+++ b/tools/recorder2parquet.cpp
@@ -1094,7 +1094,7 @@ int main(int argc, char **argv)
     {
         if (fs::is_directory(entry))
         {
-            std::string dir_string{entry.path().u8string()};
+            std::string dir_string{entry.path().string()};
             const size_t last_slash_idx = dir_string.rfind('/');
             std::string directory_name;
             if (std::string::npos != last_slash_idx)


### PR DESCRIPTION
Updates the build to work with Apache Arrow 24 by moving C++ compilation to C++20 and fixing C++20 path string handling in `recorder2parquet`.

Also relaxes the Meson constraint from `<1.10.0` to `!=1.10.0`, since the Meson 1.10.0 CMake subproject regression has been fixed in later releases. CI still installs Meson from PyPI because Ubuntu 22.04’s apt Meson is too old for the project’s `>=1.5.0` requirement.

Validation:

- Reproduced the Ubuntu 22.04 / Python 3.10 CI path locally with `act`
- Verified Arrow/Parquet `24.0.0`
- Verified Meson `1.11.1`
- `pytest -m smoke`: 91 passed, 12 deselected
- DFAnalyzer external-cluster workflow completed successfully